### PR TITLE
ci: add initial CI to run tests

### DIFF
--- a/.github/ci/keria-runtime-requirements.txt
+++ b/.github/ci/keria-runtime-requirements.txt
@@ -1,0 +1,9 @@
+hio==0.6.14
+mnemonic==0.21
+multicommand==1.0.0
+falcon==4.0.2
+http_sfv==0.9.9
+dataclasses_json==0.6.7
+apispec==6.10.0
+marshmallow_dataclass==8.7.1
+deprecation==2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Lint, build, and KERIA smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    env:
+      KERIPY_BRANCH: v1.2.13
+      KERIPY_REF: cbbf700fa8091587b96b5475c5f50d1d8bf3ca40
+      KERIA_BRANCH: main
+      KERIA_REF: aba457cab3813078bfedb65a7d819f48d86974b8
+      PUPPETEER_CACHE_DIR: /home/runner/.cache/puppeteer
+      VITE_OPERATION_TIMEOUT_MS: "45000"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsodium-dev
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.8"
+          cache: pip
+          cache-dependency-path: .github/ci/keria-runtime-requirements.txt
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Cache pinned KERI repositories
+        uses: actions/cache@v4
+        with:
+          path: .ci/deps
+          key: keri-repos-${{ runner.os }}-${{ env.KERIPY_REF }}-${{ env.KERIA_REF }}
+
+      - name: Cache Puppeteer browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            puppeteer-${{ runner.os }}-
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Puppeteer browser
+        run: pnpm exec puppeteer browsers install chrome
+
+      - name: Install pinned KERIpy and KERIA
+        run: scripts/ci/install-keri-stack.sh
+
+      - name: Start KERIA and demo witnesses
+        run: scripts/ci/start-keri-stack.sh
+
+      - name: Run CI test suite
+        run: pnpm test:ci
+
+      - name: Upload KERIA stack logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: keria-stack-logs
+          path: ${{ runner.temp }}/keri-stack/logs
+          if-no-files-found: ignore
+
+      - name: Stop KERIA stack
+        if: always()
+        run: scripts/ci/stop-keri-stack.sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - [Smoke tests](./docs/smoke-tests.md): how the CLI and browser smoke checks
   work, how to run them, required local services, configuration, outputs, and
   failure triage.
+- [CI](./docs/ci.md): GitHub Actions setup for installing pinned KERIpy/KERIA,
+  starting local services, caching dependencies, and running smoke tests.
 
 ### Run locally
 
@@ -65,3 +67,13 @@ pnpm browser:smoke
 
 See [Smoke tests](./docs/smoke-tests.md) for prerequisites, environment
 variables, output shape, and failure triage.
+
+### CI test suite
+
+The GitHub Actions workflow runs the same checks through:
+
+```bash
+pnpm test:ci
+```
+
+See [CI](./docs/ci.md) for the pinned KERIpy/KERIA versions and service setup.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,128 @@
+# CI
+
+The repository uses GitHub Actions to run the Signify boundary smoke tests
+against a real local KERIA stack.
+
+Workflow: `.github/workflows/ci.yml`
+
+## What CI Runs
+
+The main CI job:
+
+1. installs system dependencies needed by KERIpy, currently `libsodium-dev`,
+2. sets up Python 3.12.8,
+3. sets up Node.js and pnpm,
+4. installs Node dependencies from `pnpm-lock.yaml`,
+5. installs a Puppeteer browser,
+6. installs pinned KERIpy and KERIA from GitHub commits,
+7. starts local KERI demo witnesses,
+8. starts local KERIA,
+9. runs `pnpm test:ci`,
+10. uploads KERIA/witness logs on success or failure.
+
+`pnpm test:ci` currently runs:
+
+```bash
+pnpm lint
+pnpm build
+pnpm keria:smoke -- --mode connect
+pnpm keria:smoke
+pnpm browser:smoke
+```
+
+Future tests that require the same local KERIA stack should be added to
+`test:ci` or called from that script.
+
+## Pinned Python Stack
+
+CI installs these exact repositories:
+
+| Project | Branch | Commit | Version |
+| --- | --- | --- | --- |
+| KERIpy | `v1.2.13` | `cbbf700fa8091587b96b5475c5f50d1d8bf3ca40` | `keri==1.2.13` |
+| KERIA | `main` | `aba457cab3813078bfedb65a7d819f48d86974b8` | `keria==0.4.0` |
+
+The install script is `scripts/ci/install-keri-stack.sh`.
+
+KERIA `0.4.0` declares `keri==1.2.12`, but this CI intentionally tests the
+requested KERIpy `1.2.13` commit. To make that explicit, the script:
+
+1. installs KERIA runtime dependencies from
+   `.github/ci/keria-runtime-requirements.txt`,
+2. installs KERIpy from the pinned commit,
+3. installs KERIA from the pinned commit with `--no-deps`,
+4. verifies `keri.__version__ == "1.2.13"` and
+   `keria.__version__ == "0.4.0"`.
+
+Do not replace this with an unconstrained `pip install keria`; that would allow
+the resolver to choose a different KERIpy version.
+
+## Local Services
+
+The service scripts are:
+
+- `scripts/ci/start-keri-stack.sh`
+- `scripts/ci/stop-keri-stack.sh`
+
+The start script runs both services with `INFO` logging by default:
+
+```bash
+kli witness demo --loglevel INFO
+keria start --config-dir scripts --config-file demo-witness-oobis --loglevel INFO
+```
+
+The witness process is started from the cloned KERIpy checkout. That matters:
+`kli witness demo` resolves its demo witness configs relative to the KERIpy
+tree, including `scripts/keri/cf/main/wan.json`,
+`scripts/keri/cf/main/wil.json`, and `scripts/keri/cf/main/wes.json` in the
+pinned `v1.2.13` commit. The start script checks for these files before
+launching the witnesses.
+
+The KERIA process is started from the cloned KERIA checkout for the same
+reason. The pinned KERIA commit carries the demo agent and OOBI configuration
+under `scripts/keria.json`, `scripts/keri/cf/demo-witness-oobis.json`, and
+`scripts/keri/cf/keria.json`. The start script checks for those files before
+launching KERIA and then runs `keria start` from the KERIA repo root.
+
+The log levels can be overridden for a diagnostic run:
+
+```bash
+WITNESS_LOGLEVEL=DEBUG KERIA_LOGLEVEL=DEBUG scripts/ci/start-keri-stack.sh
+```
+
+Expected ports:
+
+| Service | Port |
+| --- | --- |
+| Wan witness HTTP | `5642` |
+| Wil witness HTTP | `5643` |
+| Wes witness HTTP | `5644` |
+| KERIA admin API | `3901` |
+| KERIA router API | `3902` |
+| KERIA boot API | `3903` |
+
+The start script waits for all ports before returning. Logs are written under
+`${RUNNER_TEMP}/keri-stack/logs` in GitHub Actions and uploaded as the
+`keria-stack-logs` artifact.
+
+## Caching
+
+CI uses these caches:
+
+- pnpm dependency cache via `actions/setup-node`.
+- pip cache via `actions/setup-python`.
+- pinned KERI repository clones under `.ci/deps`.
+- Puppeteer browser cache under `~/.cache/puppeteer`.
+
+The KERI repository cache key includes the pinned KERIpy and KERIA commits, so
+changing either commit creates a fresh cache.
+
+## Updating Pinned KERI Versions
+
+To update KERIpy or KERIA:
+
+1. update `KERIPY_BRANCH` / `KERIPY_REF` or `KERIA_BRANCH` / `KERIA_REF` in
+   `.github/workflows/ci.yml`,
+2. update the version assertions in `scripts/ci/install-keri-stack.sh`,
+3. update this document,
+4. run the smoke tests locally against the same versions if possible.

--- a/docs/smoke-tests.md
+++ b/docs/smoke-tests.md
@@ -30,6 +30,15 @@ pnpm browser:smoke
 Run `pnpm keria:smoke -- --mode connect` first when debugging. It proves the
 admin and boot APIs work without involving witnesses or browser automation.
 
+CI runs all smoke checks through:
+
+```bash
+pnpm test:ci
+```
+
+See [CI](./ci.md) for the GitHub Actions service setup and pinned KERIpy/KERIA
+versions.
+
 ## Infrastructure
 
 The smoke-test stack has one shared scenario and two executable wrappers.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src --max-warnings 0",
     "preview": "vite preview",
     "keria:smoke": "tsx scripts/keria-smoke.ts",
-    "browser:smoke": "node tests/browser-smoke.mjs"
+    "browser:smoke": "node tests/browser-smoke.mjs",
+    "test:ci": "pnpm lint && pnpm build && pnpm keria:smoke -- --mode connect && pnpm keria:smoke && pnpm browser:smoke"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/scripts/ci/install-keri-stack.sh
+++ b/scripts/ci/install-keri-stack.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPS_DIR="${ROOT_DIR}/.ci/deps"
+KERIPY_DIR="${DEPS_DIR}/keripy"
+KERIA_DIR="${DEPS_DIR}/keria"
+
+KERIPY_REPO="${KERIPY_REPO:-https://github.com/WebOfTrust/keripy.git}"
+KERIPY_BRANCH="${KERIPY_BRANCH:-v1.2.13}"
+KERIPY_REF="${KERIPY_REF:-cbbf700fa8091587b96b5475c5f50d1d8bf3ca40}"
+
+KERIA_REPO="${KERIA_REPO:-https://github.com/WebOfTrust/keria.git}"
+KERIA_BRANCH="${KERIA_BRANCH:-main}"
+KERIA_REF="${KERIA_REF:-aba457cab3813078bfedb65a7d819f48d86974b8}"
+
+sync_repo() {
+  local dir="$1"
+  local repo="$2"
+  local branch="$3"
+  local ref="$4"
+
+  mkdir -p "$(dirname "$dir")"
+
+  if [[ ! -d "${dir}/.git" ]]; then
+    rm -rf "$dir"
+    git clone --no-checkout "$repo" "$dir"
+  fi
+
+  git -C "$dir" remote set-url origin "$repo"
+  git -C "$dir" fetch --depth 1 origin "$branch"
+
+  if ! git -C "$dir" cat-file -e "${ref}^{commit}" 2>/dev/null; then
+    git -C "$dir" fetch --depth 1 origin "$ref" || git -C "$dir" fetch origin "$branch"
+  fi
+
+  git -C "$dir" checkout --force "$ref"
+  git -C "$dir" clean -xdf
+
+  local actual
+  actual="$(git -C "$dir" rev-parse HEAD)"
+  if [[ "$actual" != "$ref" ]]; then
+    echo "Expected ${dir} at ${ref}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+python -m pip install --upgrade pip wheel setuptools
+
+sync_repo "$KERIPY_DIR" "$KERIPY_REPO" "$KERIPY_BRANCH" "$KERIPY_REF"
+sync_repo "$KERIA_DIR" "$KERIA_REPO" "$KERIA_BRANCH" "$KERIA_REF"
+
+python -m pip install -r "${ROOT_DIR}/.github/ci/keria-runtime-requirements.txt"
+python -m pip install "$KERIPY_DIR"
+python -m pip install --no-deps "$KERIA_DIR"
+
+python - <<'PY'
+import keri
+import keria
+
+assert keri.__version__ == "1.2.13", f"expected keri 1.2.13, got {keri.__version__}"
+assert keria.__version__ == "0.4.0", f"expected keria 0.4.0, got {keria.__version__}"
+
+print(f"Installed keri {keri.__version__} and keria {keria.__version__}")
+PY

--- a/scripts/ci/start-keri-stack.sh
+++ b/scripts/ci/start-keri-stack.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPS_DIR="${ROOT_DIR}/.ci/deps"
+KERIPY_DIR="${DEPS_DIR}/keripy"
+KERIA_DIR="${DEPS_DIR}/keria"
+RUN_DIR="${RUNNER_TEMP:-${ROOT_DIR}/.ci/run}/keri-stack"
+LOG_DIR="${RUN_DIR}/logs"
+PID_DIR="${RUN_DIR}/pids"
+WITNESS_LOGLEVEL="${WITNESS_LOGLEVEL:-INFO}"
+KERIA_LOGLEVEL="${KERIA_LOGLEVEL:-INFO}"
+
+mkdir -p "$LOG_DIR" "$PID_DIR"
+
+socket_wait() {
+  local host="$1"
+  local port="$2"
+  local label="$3"
+  local attempts="${4:-120}"
+
+  python - "$host" "$port" "$label" "$attempts" <<'PY'
+import socket
+import sys
+import time
+
+host, port, label, attempts = sys.argv[1], int(sys.argv[2]), sys.argv[3], int(sys.argv[4])
+
+for _ in range(attempts):
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            print(f"{label} is listening on {host}:{port}")
+            raise SystemExit(0)
+    except OSError:
+        time.sleep(1)
+
+print(f"Timed out waiting for {label} on {host}:{port}", file=sys.stderr)
+raise SystemExit(1)
+PY
+}
+
+for config_name in wan wil wes; do
+  if [[ ! -f "${KERIPY_DIR}/scripts/keri/cf/main/${config_name}.json" ]]; then
+    echo "Missing KERIpy witness config: scripts/keri/cf/main/${config_name}.json" >&2
+    echo "Run this script from a checkout that matches the pinned KERIpy witness demo layout." >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${KERIA_DIR}/scripts/keria.json" ]]; then
+  echo "Missing KERIA config: scripts/keria.json" >&2
+  echo "Run this script after cloning the pinned KERIA repository." >&2
+  exit 1
+fi
+
+for config_name in demo-witness-oobis keria; do
+  if [[ ! -f "${KERIA_DIR}/scripts/keri/cf/${config_name}.json" ]]; then
+    echo "Missing KERIA config: scripts/keri/cf/${config_name}.json" >&2
+    echo "Run this script after cloning the pinned KERIA repository." >&2
+    exit 1
+  fi
+done
+
+echo "Starting KERI demo witnesses"
+(
+  cd "$KERIPY_DIR"
+  exec kli witness demo --loglevel "$WITNESS_LOGLEVEL"
+) >"${LOG_DIR}/witness.log" 2>&1 &
+echo "$!" >"${PID_DIR}/witness.pid"
+
+socket_wait 127.0.0.1 5642 "Wan witness"
+socket_wait 127.0.0.1 5643 "Wil witness"
+socket_wait 127.0.0.1 5644 "Wes witness"
+
+echo "Starting KERIA"
+(
+  cd "$KERIA_DIR"
+  export KERI_AGENT_CORS=1
+  exec keria start \
+    --config-dir scripts \
+    --config-file demo-witness-oobis \
+    --loglevel "$KERIA_LOGLEVEL"
+) >"${LOG_DIR}/keria.log" 2>&1 &
+echo "$!" >"${PID_DIR}/keria.pid"
+
+socket_wait 127.0.0.1 3901 "KERIA admin API"
+socket_wait 127.0.0.1 3902 "KERIA router API"
+socket_wait 127.0.0.1 3903 "KERIA boot API"
+
+echo "KERIA stack logs: ${LOG_DIR}"

--- a/scripts/ci/stop-keri-stack.sh
+++ b/scripts/ci/stop-keri-stack.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUN_DIR="${RUNNER_TEMP:-${ROOT_DIR}/.ci/run}/keri-stack"
+PID_DIR="${RUN_DIR}/pids"
+
+if [[ ! -d "$PID_DIR" ]]; then
+  exit 0
+fi
+
+for pid_file in "$PID_DIR"/*.pid; do
+  [[ -e "$pid_file" ]] || continue
+  pid="$(cat "$pid_file")"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+done
+
+sleep 2
+
+for pid_file in "$PID_DIR"/*.pid; do
+  [[ -e "$pid_file" ]] || continue
+  pid="$(cat "$pid_file")"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+done


### PR DESCRIPTION
Runs Puppeteer to drive UI tests and runs local integration tests with `kli witness demo` and `keria start` with a headless browser client.