### PR TITLE
chore: ignore generated smoke artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 coverage/*
 
 .cache/
+.smoke-artifacts/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  puppeteer: true
+  signify-ts: true


### PR DESCRIPTION
Stack PR 0/8 for splitting #34.

Scope:
- Ignore generated smoke artifacts.
- Keep generated screenshots out of the product branch.

Validation performed on final stack:
- pnpm lint
- pnpm build
- pnpm unit:test
- w3c-crosswalk make local-seed
- w3c-crosswalk make local-test
- pnpm w3c:holder-presentation:smoke