### PR TITLE
feat: add did:webs identifier projection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   smoke:
     name: Lint, build, and KERIA smoke tests
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     env:
       KERIPY_BRANCH: v1.2.13

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "react-dom": "^19.2.5",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.14.2",
-        "signify-ts": "0.3.0"
+        "signify-ts": "github:kentbull/signify-ts#8bdeb48516b4a9d8d7e6818e0bc37e4b26908ec3"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       signify-ts:
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: github:kentbull/signify-ts#8bdeb48516b4a9d8d7e6818e0bc37e4b26908ec3
+        version: https://codeload.github.com/kentbull/signify-ts/tar.gz/8bdeb48516b4a9d8d7e6818e0bc37e4b26908ec3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1899,8 +1899,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signify-ts@0.3.0:
-    resolution: {integrity: sha512-qyqYj5iXat0DoZrXxnhgzdgEkhpje1nWr+Rq8woA4lb6UoGSBkKCUVQN5N2CWWV5K9uAn5iCjqNgHw0ngA6oGg==}
+  signify-ts@https://codeload.github.com/kentbull/signify-ts/tar.gz/8bdeb48516b4a9d8d7e6818e0bc37e4b26908ec3:
+    resolution: {gitHosted: true, integrity: sha512-zp6zNU5yFlQOoc1w3iCfWA6DlrgA6VAodN5k7YTKC/yzyQmlcP6S5img6PqLwB2EW9rj6rCp0/VLYYpCnro52g==, tarball: https://codeload.github.com/kentbull/signify-ts/tar.gz/8bdeb48516b4a9d8d7e6818e0bc37e4b26908ec3}
+    version: 0.4.0
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -3962,7 +3963,7 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signify-ts@0.3.0:
+  signify-ts@https://codeload.github.com/kentbull/signify-ts/tar.gz/8bdeb48516b4a9d8d7e6818e0bc37e4b26908ec3:
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0

--- a/src/app/routeData.dashboard.ts
+++ b/src/app/routeData.dashboard.ts
@@ -13,6 +13,9 @@ export const loadDashboard = async (
     }
 
     try {
+        await runtime
+            .refreshState({ signal: request?.signal })
+            .catch(() => null);
         await runtime.identifiers.list({ signal: request?.signal });
         await Promise.all([
             runtime.contacts.syncInventory({ signal: request?.signal }),

--- a/src/app/routeData.identifiers.ts
+++ b/src/app/routeData.identifiers.ts
@@ -199,7 +199,7 @@ export const identifiersAction = async (
 
     if (runtime.getClient() === null) {
         return {
-            intent: intent === 'rotate' ? 'rotate' : 'create',
+            intent: intent === 'rotate' ? intent : 'create',
             ok: false,
             message: 'Connect to KERIA before changing identifiers.',
         };
@@ -209,7 +209,7 @@ export const identifiersAction = async (
         return runIdentifierIntentAction(context);
     } catch (error) {
         return {
-            intent: intent === 'rotate' ? 'rotate' : 'create',
+            intent: intent === 'rotate' ? intent : 'create',
             ok: false,
             message: toRouteError(error).message,
             requestId: formString(formData, 'requestId'),

--- a/src/app/routeData.types.ts
+++ b/src/app/routeData.types.ts
@@ -10,6 +10,7 @@ import type {
     ContactRuntimeCommands,
     CredentialRuntimeCommands,
     DelegationRuntimeCommands,
+    DidWebsRuntimeCommands,
     IdentifierRuntimeCommands,
     MultisigRuntimeCommands,
     NotificationRuntimeCommands,
@@ -292,4 +293,6 @@ export interface RouteDataRuntime {
     credentials: CredentialRuntimeCommands;
     /** Multisig route commands. */
     multisig: MultisigRuntimeCommands;
+    /** did:webs DID route commands. */
+    didwebs: DidWebsRuntimeCommands;
 }

--- a/src/app/runtime.ts
+++ b/src/app/runtime.ts
@@ -54,6 +54,7 @@ import {
     createContactRuntimeCommands,
     createCredentialRuntimeCommands,
     createDelegationRuntimeCommands,
+    createDidWebsRuntimeCommands,
     createIdentifierRuntimeCommands,
     createMultisigRuntimeCommands,
     createNotificationRuntimeCommands,
@@ -63,6 +64,7 @@ import {
     type ContactRuntimeCommands,
     type CredentialRuntimeCommands,
     type DelegationRuntimeCommands,
+    type DidWebsRuntimeCommands,
     type IdentifierRuntimeCommands,
     type MultisigRuntimeCommands,
     type NotificationRuntimeCommands,
@@ -221,6 +223,9 @@ export class AppRuntime {
     /** Multisig group command adapter. */
     readonly multisig: MultisigRuntimeCommands;
 
+    /** did:webs DID command adapter. */
+    readonly didwebs: DidWebsRuntimeCommands;
+
     /** Foreground and background task handles keyed by route request id. */
     private readonly activeTasks = new Map<string, Task<unknown>>();
 
@@ -276,6 +281,7 @@ export class AppRuntime {
         this.delegations = createDelegationRuntimeCommands(commandContext);
         this.credentials = createCredentialRuntimeCommands(commandContext);
         this.multisig = createMultisigRuntimeCommands(commandContext);
+        this.didwebs = createDidWebsRuntimeCommands(commandContext);
 
         this.storage =
             options.storage === undefined ? undefined : options.storage;

--- a/src/app/runtimeCommands/contacts.ts
+++ b/src/app/runtimeCommands/contacts.ts
@@ -10,11 +10,13 @@ import type { GeneratedOobiRecord } from '../../state/contacts.slice';
 import {
     deleteContactOp,
     generateOobiOp,
+    listIdentifierOobisOp,
     liveSessionInventoryOp,
     resolveContactOobiOp,
     syncSessionInventoryOp,
     updateContactAliasOp,
     type GenerateOobiInput,
+    type ListIdentifierOobisInput,
     type SessionInventorySnapshot,
     type UpdateContactAliasInput,
 } from '../../workflows/contacts.op';
@@ -29,7 +31,9 @@ import type {
 } from './types';
 
 export interface ContactRuntimeCommands {
-    syncInventory(options?: WorkflowRunOptions): Promise<SessionInventorySnapshot>;
+    syncInventory(
+        options?: WorkflowRunOptions
+    ): Promise<SessionInventorySnapshot>;
     getIdentifierOobi(
         input: GenerateOobiInput,
         options?: WorkflowRunOptions
@@ -99,27 +103,18 @@ const getIdentifierOobi =
 
 const listIdentifierOobis =
     (context: RuntimeCommandContext) =>
-    async (
+    (
         identifier: string,
         roles: readonly OobiRole[],
         options: WorkflowRunOptions = {}
     ): Promise<GeneratedOobiRecord[]> => {
-        const loadOobi = getIdentifierOobi(context);
-        const records: GeneratedOobiRecord[] = [];
-        for (const role of roles) {
-            records.push(
-                await loadOobi(
-                    { identifier, role },
-                    {
-                        ...options,
-                        label: options.label,
-                        track: options.track ?? false,
-                    }
-                )
-            );
-        }
-
-        return records;
+        const input: ListIdentifierOobisInput = { identifier, roles };
+        return context.runWorkflow(() => listIdentifierOobisOp(input), {
+            ...options,
+            label: options.label,
+            kind: options.kind ?? 'workflow',
+            track: options.track ?? false,
+        });
     };
 
 const startGenerateOobi =

--- a/src/app/runtimeCommands/didwebs.ts
+++ b/src/app/runtimeCommands/didwebs.ts
@@ -1,0 +1,34 @@
+import { refreshIdentifierDidWebsOp } from '../../workflows/didwebs.op';
+import type { DidWebsDidPayload } from '../../state/didwebs.slice';
+import type { RuntimeCommandContext, WorkflowRunOptions } from './types';
+
+export interface DidWebsRuntimeCommands {
+    refreshIdentifierDid(
+        name: string,
+        aid: string,
+        options?: WorkflowRunOptions
+    ): Promise<DidWebsDidPayload | null>;
+}
+
+/**
+ * Route-facing did:webs DID commands.
+ */
+export const createDidWebsRuntimeCommands = (
+    context: RuntimeCommandContext
+): DidWebsRuntimeCommands => ({
+    refreshIdentifierDid: refreshIdentifierDid(context),
+});
+
+const refreshIdentifierDid =
+    (context: RuntimeCommandContext) =>
+    (
+        name: string,
+        aid: string,
+        options: WorkflowRunOptions = {}
+    ): Promise<DidWebsDidPayload | null> =>
+        context.runWorkflow(() => refreshIdentifierDidWebsOp({ name, aid }), {
+            ...options,
+            label: options.label,
+            kind: options.kind ?? 'refreshDidWebsDid',
+            track: options.track ?? false,
+        });

--- a/src/app/runtimeCommands/identifiers.ts
+++ b/src/app/runtimeCommands/identifiers.ts
@@ -148,14 +148,14 @@ const startRotateIdentifier =
     (context: RuntimeCommandContext) =>
     (aid: string, options: RequestIdOptions = {}): BackgroundWorkflowStartResult => {
         const requestId = requestIdFrom(context, options);
-        const identifier = identifierForRotation(context.getState(), aid);
+        const identifier = identifierForAid(context.getState(), aid);
         return context.startBackgroundWorkflow(
             () => rotateIdentifierBackgroundOp(aid, requestId),
             rotateIdentifierOptions(aid, requestId, identifier)
         );
     };
 
-const identifierForRotation = (
+const identifierForAid = (
     state: RootState,
     aid: string
 ): IdentifierSummary | null =>

--- a/src/app/runtimeCommands/index.ts
+++ b/src/app/runtimeCommands/index.ts
@@ -15,6 +15,10 @@ export {
     type DelegationRuntimeCommands,
 } from './delegations';
 export {
+    createDidWebsRuntimeCommands,
+    type DidWebsRuntimeCommands,
+} from './didwebs';
+export {
     createIdentifierRuntimeCommands,
     type IdentifierRuntimeCommands,
 } from './identifiers';

--- a/src/domain/didwebs/didWebsUrls.ts
+++ b/src/domain/didwebs/didWebsUrls.ts
@@ -1,0 +1,47 @@
+export interface DidWebsAssetUrls {
+    didJsonUrl: string;
+    keriCesrUrl: string;
+}
+
+const DID_WEBS_PREFIX = 'did:webs:';
+
+const loopbackHost = (hostPort: string): boolean => {
+    if (hostPort === '::1' || hostPort.startsWith('[::1]')) {
+        return true;
+    }
+
+    const host = hostPort.startsWith('[')
+        ? hostPort.slice(1, hostPort.indexOf(']'))
+        : hostPort.split(':')[0];
+
+    return (
+        host === 'localhost' ||
+        host === '127.0.0.1' ||
+        host.startsWith('127.')
+    );
+};
+
+/** Derive KERIA did:webs asset URLs from a did:webs DID. */
+export const didWebsAssetUrlsFromDid = (
+    did: string
+): DidWebsAssetUrls | null => {
+    if (!did.startsWith(DID_WEBS_PREFIX)) {
+        return null;
+    }
+
+    const methodSpecificId = did.slice(DID_WEBS_PREFIX.length).split('?')[0];
+    const segments = methodSpecificId.split(':').filter(Boolean);
+    if (segments.length < 2) {
+        return null;
+    }
+
+    const hostPort = decodeURIComponent(segments[0]);
+    const path = segments.slice(1).join('/');
+    const scheme = loopbackHost(hostPort) ? 'http' : 'https';
+    const base = `${scheme}://${hostPort}/${path}`;
+
+    return {
+        didJsonUrl: `${base}/did.json`,
+        keriCesrUrl: `${base}/keri.cesr`,
+    };
+};

--- a/src/features/dashboard/DashboardOverview.tsx
+++ b/src/features/dashboard/DashboardOverview.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Button,
     List,
     ListItem,
     ListItemText,
@@ -7,7 +8,13 @@ import {
     Typography,
 } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
-import { ConsolePanel, EmptyState, PageHeader, StatusPill, TelemetryRow } from '../../app/Console';
+import {
+    ConsolePanel,
+    EmptyState,
+    PageHeader,
+    StatusPill,
+    TelemetryRow,
+} from '../../app/Console';
 import { clickablePanelSx } from '../../app/consoleStyles';
 import { UI_SOUND_HOVER_VALUE } from '../../app/uiSound';
 import type { DashboardLoaderData } from '../../app/routeData';
@@ -248,7 +255,21 @@ export const DashboardOverview = ({
                     to="/contacts"
                 />
             </Box>
-            <ConsolePanel title="Agent information" eyebrow="KERIA" to="/client">
+            <ConsolePanel
+                title="Agent information"
+                eyebrow="KERIA"
+                actions={
+                    <Button
+                        component={RouterLink}
+                        to="/client"
+                        size="small"
+                        variant="outlined"
+                        data-ui-sound={UI_SOUND_HOVER_VALUE}
+                    >
+                        Client Console
+                    </Button>
+                }
+            >
                 <TelemetryRow
                     label="Controller AID"
                     value={session.controllerAid ?? 'Not connected'}

--- a/src/features/dashboard/DashboardView.tsx
+++ b/src/features/dashboard/DashboardView.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react';
-import { useLoaderData, useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+    useLoaderData,
+    useLocation,
+    useNavigate,
+    useParams,
+} from 'react-router-dom';
 import { ConnectionRequired } from '../../app/ConnectionRequired';
 import { useAppSession } from '../../app/runtimeHooks';
 import type { DashboardLoaderData } from '../../app/routeData';
@@ -46,13 +51,19 @@ export const DashboardView = () => {
     const session = useAppSelector(selectSession);
     const counts = useAppSelector(selectDashboardCounts);
     const recentOperations = useAppSelector(selectRecentOperations(5));
-    const recentKeriaNotifications = useAppSelector(selectRecentKeriaNotifications(5));
-    const recentAppNotifications = useAppSelector(selectRecentAppNotifications(5));
+    const recentKeriaNotifications = useAppSelector(
+        selectRecentKeriaNotifications(5)
+    );
+    const recentAppNotifications = useAppSelector(
+        selectRecentAppNotifications(5)
+    );
     const recentChallenges = useAppSelector(selectRecentChallenges(5));
     const resolvedSchemas = useAppSelector(selectResolvedCredentialSchemas);
     const issuedCredentials = useAppSelector(selectIssuedCredentials);
     const heldCredentials = useAppSelector(selectHeldCredentials);
-    const grantNotifications = useAppSelector(selectCredentialGrantNotifications);
+    const grantNotifications = useAppSelector(
+        selectCredentialGrantNotifications
+    );
     const selectedCredentialExchangeActivities = useAppSelector(
         selectCredentialIpexActivity(credentialSaid)
     );
@@ -60,7 +71,8 @@ export const DashboardView = () => {
     const contacts = useAppSelector(selectContacts);
     const identifiers = useAppSelector(selectIdentifiers);
     const connection = runtimeSnapshot.connection;
-    const connectionUrl = connection.status === 'connected' ? connection.client.url : null;
+    const connectionUrl =
+        connection.status === 'connected' ? connection.client.url : null;
     const registriesById = useMemo(
         () => buildDashboardRegistryMap(registries),
         [registries]

--- a/src/features/didwebs/DidWebsPublicationDetails.tsx
+++ b/src/features/didwebs/DidWebsPublicationDetails.tsx
@@ -1,0 +1,159 @@
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import { StatusPill } from '../../app/Console';
+import { monoValueSx } from '../../app/consoleStyles';
+import { didWebsAssetUrlsFromDid } from '../../domain/didwebs/didWebsUrls';
+import type { DidWebsDidRecord } from '../../state/didwebs.slice';
+
+const PENDING_VALUE = '...pending...';
+
+const copyText = (value: string): void => {
+    void globalThis.navigator?.clipboard?.writeText(value);
+};
+
+const displayState = (record: DidWebsDidRecord | null): string => {
+    if (record?.did !== null && record?.did !== undefined) {
+        return 'ready';
+    }
+    if (record?.loadState === 'loading') {
+        return 'loading';
+    }
+    if (record?.loadState === 'error') {
+        return 'error';
+    }
+    return 'pending';
+};
+
+const statusTone = (
+    record: DidWebsDidRecord | null
+): 'neutral' | 'success' | 'warning' | 'error' | 'info' => {
+    if (record?.did !== null && record?.did !== undefined) {
+        return 'success';
+    }
+    if (record?.loadState === 'error') {
+        return 'error';
+    }
+    if (record?.loadState === 'loading') {
+        return 'warning';
+    }
+    return 'info';
+};
+
+const readyValue = (value: string | null | undefined): string =>
+    value ?? PENDING_VALUE;
+
+const DetailRow = ({
+    label,
+    value,
+    copyable,
+    testId,
+}: {
+    label: string;
+    value: string;
+    copyable: boolean;
+    testId?: string;
+}) => (
+    <Box
+        sx={{
+            display: 'grid',
+            gridTemplateColumns: copyable ? 'minmax(0, 1fr) auto' : '1fr',
+            gap: 1,
+            alignItems: 'start',
+            minWidth: 0,
+        }}
+    >
+        <Box sx={{ minWidth: 0 }}>
+            <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: 'block', fontWeight: 700 }}
+            >
+                {label}
+            </Typography>
+            <Typography
+                variant="body2"
+                data-testid={testId}
+                sx={{
+                    ...monoValueSx,
+                    color: value === PENDING_VALUE ? 'text.secondary' : 'text.primary',
+                }}
+            >
+                {value}
+            </Typography>
+        </Box>
+        {copyable && (
+            <Tooltip title={`Copy ${label}`}>
+                <IconButton
+                    size="small"
+                    aria-label={`copy ${label}`}
+                    onClick={() => copyText(value)}
+                >
+                    <ContentCopyIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+        )}
+    </Box>
+);
+
+export interface DidWebsPublicationDetailsProps {
+    record: DidWebsDidRecord | null;
+    testIdPrefix: string;
+}
+
+/** Render copyable did:webs material once a DID is available. */
+export const DidWebsPublicationDetails = ({
+    record,
+    testIdPrefix,
+}: DidWebsPublicationDetailsProps) => {
+    const did = record?.did ?? null;
+    const derivedUrls = did === null ? null : didWebsAssetUrlsFromDid(did);
+    const didJsonUrl = record?.didJsonUrl ?? derivedUrls?.didJsonUrl ?? null;
+    const keriCesrUrl =
+        record?.keriCesrUrl ?? derivedUrls?.keriCesrUrl ?? null;
+
+    return (
+        <Stack spacing={1.25} data-testid={`${testIdPrefix}-didwebs`}>
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: { xs: '1fr', sm: '160px 1fr' },
+                    gap: { xs: 0.5, sm: 1.5 },
+                    alignItems: 'center',
+                    minWidth: 0,
+                }}
+            >
+                <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ fontWeight: 700 }}
+                >
+                    Status
+                </Typography>
+                <StatusPill label={displayState(record)} tone={statusTone(record)} />
+            </Box>
+            <DetailRow
+                label="did:webs DID"
+                value={readyValue(did)}
+                copyable={did !== null}
+                testId={`${testIdPrefix}-didwebs-did`}
+            />
+            <DetailRow
+                label="did.json URL"
+                value={readyValue(didJsonUrl)}
+                copyable={didJsonUrl !== null}
+                testId={`${testIdPrefix}-didwebs-did-json-url`}
+            />
+            <DetailRow
+                label="keri.cesr URL"
+                value={readyValue(keriCesrUrl)}
+                copyable={keriCesrUrl !== null}
+                testId={`${testIdPrefix}-didwebs-keri-cesr-url`}
+            />
+            {record?.loadState === 'error' && record.error !== null && (
+                <Typography color="error" variant="body2">
+                    {record.error}
+                </Typography>
+            )}
+        </Stack>
+    );
+};

--- a/src/features/identifiers/IdentifierDetailsModal.tsx
+++ b/src/features/identifiers/IdentifierDetailsModal.tsx
@@ -20,6 +20,8 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import RotateRightIcon from '@mui/icons-material/RotateRight';
 import type { GeneratedOobiRecord } from '../../state/contacts.slice';
+import type { DidWebsDidRecord } from '../../state/didwebs.slice';
+import { DidWebsPublicationDetails } from '../didwebs/DidWebsPublicationDetails';
 import type {
     IdentifierDelegationChainNode,
     IdentifierDelegationChainState,
@@ -47,6 +49,7 @@ export interface IdentifierDetailsModalProps {
     refreshMessage: string | null;
     oobiState: IdentifierOobiDetailState;
     delegationChain: IdentifierDelegationChainState;
+    didWebsDid: DidWebsDidRecord | null;
     actionRunning: boolean;
     onClose: () => void;
     onRotate: (name: string) => void;
@@ -235,6 +238,7 @@ export const IdentifierDetailsModal = ({
     refreshMessage,
     oobiState,
     delegationChain,
+    didWebsDid,
     actionRunning,
     onClose,
     onRotate,
@@ -259,6 +263,7 @@ export const IdentifierDetailsModal = ({
             aria-describedby="modal-modal-description"
             fullWidth
             maxWidth="md"
+            data-testid="identifier-details-modal"
             slotProps={{
                 paper: {
                     sx: {
@@ -414,6 +419,17 @@ export const IdentifierDetailsModal = ({
                         </AccordionSummary>
                         <AccordionDetails>
                             <IdentifierOobis state={oobiState} />
+                        </AccordionDetails>
+                    </Accordion>
+                    <Accordion disableGutters defaultExpanded>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography>did:webs DID</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <DidWebsPublicationDetails
+                                record={didWebsDid}
+                                testIdPrefix="identifier"
+                            />
                         </AccordionDetails>
                     </Accordion>
                     {identifier !== null && (

--- a/src/features/identifiers/IdentifierTable.tsx
+++ b/src/features/identifiers/IdentifierTable.tsx
@@ -248,7 +248,9 @@ export const IdentifierTable = ({
                         >
                             <OobiCopyButton
                                 identifier={identifier}
-                                copyStatus={agentOobiCopyStatus[identifier.name]}
+                                copyStatus={
+                                    agentOobiCopyStatus[identifier.name]
+                                }
                                 onCopy={copyAgentOobi}
                             />
                             <Tooltip title="Rotate identifier">
@@ -319,7 +321,10 @@ export const IdentifierTable = ({
                             >
                                 OOBI
                             </TableCell>
-                            <TableCell align="right" sx={stickyActionHeadCellSx}>
+                            <TableCell
+                                align="right"
+                                sx={stickyActionHeadCellSx}
+                            >
                                 Actions
                             </TableCell>
                         </TableRow>
@@ -427,7 +432,10 @@ export const IdentifierTable = ({
                                                         identifier
                                                     )}
                                                     onClick={(event) =>
-                                                        rotate(event, identifier)
+                                                        rotate(
+                                                            event,
+                                                            identifier
+                                                        )
                                                     }
                                                 >
                                                     <RotateRightIcon fontSize="small" />

--- a/src/features/identifiers/IdentifiersView.tsx
+++ b/src/features/identifiers/IdentifiersView.tsx
@@ -31,6 +31,7 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
     selectActiveOperations,
     selectContacts,
+    selectDidWebsDidByAid,
     selectIdentifiers,
 } from '../../state/selectors';
 import { walletAidSelected } from '../../state/walletSelection.slice';
@@ -107,6 +108,9 @@ export const IdentifiersView = () => {
             : (identifiers.find(
                   (identifier) => identifier.name === selectedIdentifierName
               ) ?? null);
+    const selectedDidWebsDid = useAppSelector(
+        selectDidWebsDidByAid(selectedIdentifier?.prefix)
+    );
 
     useEffect(() => {
         if (selectedIdentifierName === null) {
@@ -129,36 +133,72 @@ export const IdentifiersView = () => {
                 }
 
                 setDetailRefresh({ status: 'success', message: null });
-
-                const chain = await runtime.identifiers.getDelegationChain(
-                    refreshed.name,
-                    {
+                void runtime.didwebs
+                    .refreshIdentifierDid(refreshed.name, refreshed.prefix, {
                         signal: controller.signal,
                         track: false,
+                    })
+                    .catch(() => undefined);
+
+                try {
+                    const chain = await runtime.identifiers.getDelegationChain(
+                        refreshed.name,
+                        {
+                            signal: controller.signal,
+                            track: false,
+                        }
+                    );
+                    if (!controller.signal.aborted) {
+                        setDelegationChain({
+                            status: 'success',
+                            message: null,
+                            nodes: chain,
+                        });
                     }
-                );
-                if (!controller.signal.aborted) {
+                } catch (error: unknown) {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+
                     setDelegationChain({
-                        status: 'success',
-                        message: null,
-                        nodes: chain,
+                        status: 'error',
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                        nodes: [],
                     });
                 }
 
-                const roles = identifierAvailableOobiRoles(refreshed);
-                const records = await runtime.contacts.listIdentifierOobis(
-                    refreshed.name,
-                    roles,
-                    {
-                        signal: controller.signal,
-                        track: false,
+                try {
+                    const roles = identifierAvailableOobiRoles(refreshed);
+                    const records = await runtime.contacts.listIdentifierOobis(
+                        refreshed.name,
+                        roles,
+                        {
+                            signal: controller.signal,
+                            track: false,
+                        }
+                    );
+                    if (!controller.signal.aborted) {
+                        setDetailOobis({
+                            status: 'success',
+                            message: null,
+                            records,
+                        });
                     }
-                );
-                if (!controller.signal.aborted) {
+                } catch (error: unknown) {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+
                     setDetailOobis({
-                        status: 'success',
-                        message: null,
-                        records,
+                        status: 'error',
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                        records: [],
                     });
                 }
             } catch (error: unknown) {
@@ -434,6 +474,7 @@ export const IdentifiersView = () => {
                 refreshMessage={detailRefresh.message}
                 oobiState={detailOobis}
                 delegationChain={delegationChain}
+                didWebsDid={selectedDidWebsDid}
                 actionRunning={
                     selectedIdentifierName === null
                         ? false

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -1,8 +1,4 @@
-import type {
-    Contact,
-    Operation as KeriaOperation,
-    SignifyClient,
-} from 'signify-ts';
+import type { Contact, SignifyClient } from 'signify-ts';
 import type { Operation as EffectionOperation } from 'effection';
 import { callPromise } from '../effects/promise';
 import {
@@ -19,6 +15,7 @@ import type {
 import type { ChallengeRecord } from '../domain/challenges/challengeTypes';
 import type { OperationLogger } from '../signify/client';
 import { waitOperationService } from './signify.service';
+import { ensureAgentEndRoleService } from './identifiers.service';
 
 /**
  * OOBI role variants the UI can ask KERIA to generate for an identifier.
@@ -66,32 +63,6 @@ const completedOperationAid = (operation: unknown): string | null => {
     return stringValue(operation.response.i);
 };
 
-const hasEndRole = (raw: unknown, role: string, eid: string): boolean =>
-    Array.isArray(raw) &&
-    raw.some(
-        (item) =>
-            isRecord(item) &&
-            item.role === role &&
-            stringValue(item.eid) === eid
-    );
-
-const listIdentifierEndRoles = ({
-    client,
-    identifier,
-    role,
-}: {
-    client: SignifyClient;
-    identifier: string;
-    role: string;
-}): Promise<unknown> =>
-    client
-        .fetch(
-            `/identifiers/${encodeURIComponent(identifier)}/endroles/${encodeURIComponent(role)}`,
-            'GET',
-            null
-        )
-        .then((response) => response.json());
-
 /**
  * Load contacts and contact-derived challenge facts from KERIA.
  */
@@ -112,47 +83,6 @@ export function* listContactsService({
         challenges: challengeRecordsFromKeriaContacts(contacts, loadedAt),
         loadedAt,
     };
-}
-
-/**
- * Ensure the local identifier has authorized this KERIA agent as its `agent`
- * endpoint role before generating an agent OOBI.
- */
-export function* ensureAgentEndRoleService({
-    client,
-    identifier,
-    logger,
-}: {
-    client: SignifyClient;
-    identifier: string;
-    logger?: OperationLogger;
-}): EffectionOperation<void> {
-    const agentPre = client.agent?.pre;
-    if (agentPre === undefined) {
-        throw new Error('Connected Signify client is missing its agent AID.');
-    }
-
-    const existing = yield* callPromise(() =>
-        listIdentifierEndRoles({
-            client,
-            identifier,
-            role: 'agent',
-        })
-    );
-    if (hasEndRole(existing, 'agent', agentPre)) {
-        return;
-    }
-
-    const result = yield* callPromise(() =>
-        client.identifiers().addEndRole(identifier, 'agent', agentPre)
-    );
-    const operation = (yield* callPromise(() => result.op())) as KeriaOperation;
-    yield* waitOperationService({
-        client,
-        operation,
-        label: `authorizing ${identifier} agent endpoint`,
-        logger,
-    });
 }
 
 /**
@@ -180,6 +110,39 @@ export function* generateIdentifierOobiService({
     const oobis = result.oobis.filter((oobi) => oobi.trim().length > 0);
     if (oobis.length === 0) {
         throw new Error(`KERIA returned no ${role} OOBIs for ${identifier}.`);
+    }
+
+    return {
+        id: `${identifier}:${role}`,
+        identifier,
+        role,
+        oobis,
+        generatedAt: new Date().toISOString(),
+    };
+}
+
+/**
+ * Read any currently available OOBIs for a local identifier role.
+ *
+ * Unlike `generateIdentifierOobiService`, this is intentionally read-only: it
+ * never creates endpoint-role authorizations and treats missing OOBIs as normal
+ * unavailable state.
+ */
+export function* readIdentifierOobiService({
+    client,
+    identifier,
+    role,
+}: {
+    client: SignifyClient;
+    identifier: string;
+    role: OobiRole;
+}): EffectionOperation<GeneratedOobiRecord | null> {
+    const result = yield* callPromise(() =>
+        client.oobis().get(identifier, role)
+    );
+    const oobis = result.oobis.filter((oobi) => oobi.trim().length > 0);
+    if (oobis.length === 0) {
+        return null;
     }
 
     return {

--- a/src/services/identifiers.service.ts
+++ b/src/services/identifiers.service.ts
@@ -49,6 +49,9 @@ export interface IdentifierMutationResult {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null;
 
+const stringValue = (value: unknown): string | null =>
+    typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+
 const operationName = (operation: KeriaOperation): string | null => {
     const candidate = (operation as { name?: unknown }).name;
     return typeof candidate === 'string' ? candidate : null;
@@ -66,6 +69,32 @@ const eventFromResult = (result: unknown): unknown => {
 
     return serder.sad;
 };
+
+const hasEndRole = (raw: unknown, role: string, eid: string): boolean =>
+    Array.isArray(raw) &&
+    raw.some(
+        (item) =>
+            isRecord(item) &&
+            item.role === role &&
+            stringValue(item.eid) === eid
+    );
+
+const listIdentifierEndRoles = ({
+    client,
+    identifier,
+    role,
+}: {
+    client: SignifyClient;
+    identifier: string;
+    role: string;
+}): Promise<unknown> =>
+    client
+        .fetch(
+            `/identifiers/${encodeURIComponent(identifier)}/endroles/${encodeURIComponent(role)}`,
+            'GET',
+            null
+        )
+        .then((response) => response.json());
 
 function* waitDelegationApproval({
     client,
@@ -131,6 +160,47 @@ export function* getIdentifierService({
     aid: string;
 }): EffectionOperation<IdentifierSummary> {
     return yield* callPromise(() => client.identifiers().get(aid));
+}
+
+/**
+ * Ensure the local identifier has authorized this KERIA agent as its `agent`
+ * endpoint role. Existing matching authorizations are treated as success.
+ */
+export function* ensureAgentEndRoleService({
+    client,
+    identifier,
+    logger,
+}: {
+    client: SignifyClient;
+    identifier: string;
+    logger?: OperationLogger;
+}): EffectionOperation<void> {
+    const agentPre = client.agent?.pre;
+    if (agentPre === undefined) {
+        throw new Error('Connected Signify client is missing its agent AID.');
+    }
+
+    const existing = yield* callPromise(() =>
+        listIdentifierEndRoles({
+            client,
+            identifier,
+            role: 'agent',
+        })
+    );
+    if (hasEndRole(existing, 'agent', agentPre)) {
+        return;
+    }
+
+    const result = yield* callPromise(() =>
+        client.identifiers().addEndRole(identifier, 'agent', agentPre)
+    );
+    const operation = (yield* callPromise(() => result.op())) as KeriaOperation;
+    yield* waitOperationService({
+        client,
+        operation,
+        label: `authorizing ${identifier} agent endpoint`,
+        logger,
+    });
 }
 
 /**

--- a/src/state/didwebs.slice.ts
+++ b/src/state/didwebs.slice.ts
@@ -1,0 +1,133 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import {
+    sessionConnectionFailed,
+    sessionConnecting,
+    sessionDisconnected,
+} from './session.slice';
+
+/** Loading lifecycle for one did:webs DID projection. */
+export type DidWebsLoadState =
+    | 'idle'
+    | 'loading'
+    | 'ready'
+    | 'pending'
+    | 'error';
+
+/** Serializable did:webs DID facts keyed by AID. */
+export interface DidWebsDidRecord {
+    aid: string;
+    loadState: DidWebsLoadState;
+    did: string | null;
+    didJsonUrl: string | null;
+    keriCesrUrl: string | null;
+    error: string | null;
+    updatedAt: string | null;
+}
+
+/** did:webs DID cache normalized by AID. */
+export interface DidWebsState {
+    byAid: Record<string, DidWebsDidRecord>;
+}
+
+export interface DidWebsDidPayload {
+    aid: string;
+    did: string | null;
+    didJsonUrl: string | null;
+    keriCesrUrl: string | null;
+    updatedAt: string;
+}
+
+const createInitialState = (): DidWebsState => ({
+    byAid: {},
+});
+
+const initialState = createInitialState();
+
+const emptyRecord = (aid: string): DidWebsDidRecord => ({
+    aid,
+    loadState: 'idle',
+    did: null,
+    didJsonUrl: null,
+    keriCesrUrl: null,
+    error: null,
+    updatedAt: null,
+});
+
+const recordFor = (
+    state: DidWebsState,
+    aid: string
+): DidWebsDidRecord => {
+    state.byAid[aid] ??= emptyRecord(aid);
+    return state.byAid[aid];
+};
+
+const applyDidPayload = (
+    record: DidWebsDidRecord,
+    payload: DidWebsDidPayload
+): void => {
+    record.loadState = payload.did === null ? 'pending' : 'ready';
+    record.did = payload.did;
+    record.didJsonUrl = payload.didJsonUrl;
+    record.keriCesrUrl = payload.keriCesrUrl;
+    record.error = null;
+    record.updatedAt = payload.updatedAt;
+};
+
+/** Redux slice for did:webs DID projections. */
+export const didWebsSlice = createSlice({
+    name: 'didwebs',
+    initialState,
+    reducers: {
+        didWebsDidLoading(
+            state,
+            {
+                payload,
+            }: PayloadAction<{
+                aid: string;
+                updatedAt: string;
+            }>
+        ) {
+            const record = recordFor(state, payload.aid);
+            record.loadState = 'loading';
+            record.error = null;
+            record.updatedAt = payload.updatedAt;
+        },
+        didWebsDidLoaded(
+            state,
+            { payload }: PayloadAction<DidWebsDidPayload>
+        ) {
+            applyDidPayload(recordFor(state, payload.aid), payload);
+        },
+        didWebsDidFailed(
+            state,
+            {
+                payload,
+            }: PayloadAction<{
+                aid: string;
+                error: string;
+                updatedAt: string;
+            }>
+        ) {
+            const record = recordFor(state, payload.aid);
+            record.loadState = 'error';
+            record.error = payload.error;
+            record.updatedAt = payload.updatedAt;
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(sessionConnecting, createInitialState)
+            .addCase(sessionConnectionFailed, createInitialState)
+            .addCase(sessionDisconnected, createInitialState);
+    },
+});
+
+/** Action creators for did:webs DID updates. */
+export const {
+    didWebsDidFailed,
+    didWebsDidLoaded,
+    didWebsDidLoading,
+} = didWebsSlice.actions;
+
+/** Reducer mounted at `state.didwebs`. */
+export const didWebsReducer = didWebsSlice.reducer;

--- a/src/state/operations.slice.ts
+++ b/src/state/operations.slice.ts
@@ -19,6 +19,7 @@ export type OperationKind =
     | 'connect'
     | 'generatePasscode'
     | 'refreshState'
+    | 'refreshDidWebsDid'
     | 'listIdentifiers'
     | 'createIdentifier'
     | 'rotateIdentifier'

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -29,6 +29,13 @@ import {
 /** Select the serializable session connection summary. */
 export const selectSession = (state: RootState) => state.session;
 
+/** Select did:webs DID facts for one AID. */
+export const selectDidWebsDidByAid =
+    (aid: string | null | undefined) => (state: RootState) =>
+        aid === null || aid === undefined
+            ? null
+            : (state.didwebs.byAid[aid] ?? null);
+
 /** Select only the session status for shell rendering. */
 export const selectConnectionStatus = (state: RootState) =>
     state.session.status;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -3,6 +3,7 @@ import { appNotificationsReducer } from './appNotifications.slice';
 import { challengesReducer } from './challenges.slice';
 import { contactsReducer } from './contacts.slice';
 import { credentialsReducer } from './credentials.slice';
+import { didWebsReducer } from './didwebs.slice';
 import { exchangeTombstonesReducer } from './exchangeTombstones.slice';
 import { identifiersReducer } from './identifiers.slice';
 import { multisigReducer } from './multisig.slice';
@@ -29,6 +30,7 @@ export const createAppStore = () =>
             challenges: challengesReducer,
             exchangeTombstones: exchangeTombstonesReducer,
             credentials: credentialsReducer,
+            didwebs: didWebsReducer,
             identifiers: identifiersReducer,
             multisig: multisigReducer,
             notifications: notificationsReducer,

--- a/src/workflows/contacts.op.ts
+++ b/src/workflows/contacts.op.ts
@@ -9,6 +9,7 @@ import {
     deleteContactService,
     generateIdentifierOobiService,
     listContactsService,
+    readIdentifierOobiService,
     resolveContactOobiService,
     updateContactAliasService,
     type ContactInventorySnapshot,
@@ -40,6 +41,14 @@ import type { ChallengeRecord } from '../domain/challenges/challengeTypes';
 export interface GenerateOobiInput {
     identifier: string;
     role: OobiRole;
+}
+
+/**
+ * Workflow command for reading currently available identifier OOBIs.
+ */
+export interface ListIdentifierOobisInput {
+    identifier: string;
+    roles: readonly OobiRole[];
 }
 
 /**
@@ -275,6 +284,29 @@ export function* generateOobiOp(
 
     services.store.dispatch(generatedOobiRecorded(record));
     return record;
+}
+
+/**
+ * Read available local identifier OOBIs without creating endpoint roles.
+ */
+export function* listIdentifierOobisOp({
+    identifier,
+    roles,
+}: ListIdentifierOobisInput): EffectionOperation<GeneratedOobiRecord[]> {
+    const services = yield* AppServicesContext.expect();
+    const records: GeneratedOobiRecord[] = [];
+    for (const role of roles) {
+        const record = yield* readIdentifierOobiService({
+            client: services.runtime.requireConnectedClient(),
+            identifier,
+            role,
+        });
+        if (record !== null) {
+            records.push(record);
+        }
+    }
+
+    return records;
 }
 
 /**

--- a/src/workflows/didwebs.op.ts
+++ b/src/workflows/didwebs.op.ts
@@ -1,0 +1,53 @@
+import type { Operation as EffectionOperation } from 'effection';
+import { callPromise, toErrorText } from '../effects/promise';
+import { AppServicesContext } from '../effects/contexts';
+import {
+    didWebsDidFailed,
+    didWebsDidLoaded,
+    didWebsDidLoading,
+    type DidWebsDidPayload,
+} from '../state/didwebs.slice';
+
+/**
+ * Refresh one managed identifier did:webs DID into Redux.
+ */
+export function* refreshIdentifierDidWebsOp({
+    name,
+    aid,
+}: {
+    name: string;
+    aid: string;
+}): EffectionOperation<DidWebsDidPayload | null> {
+    const services = yield* AppServicesContext.expect();
+    const updatedAt = new Date().toISOString();
+    services.store.dispatch(
+        didWebsDidLoading({
+            aid,
+            updatedAt,
+        })
+    );
+
+    try {
+        const dws = yield* callPromise(() =>
+            services.runtime.requireConnectedClient().identifiers().dws(name)
+        );
+        const payload: DidWebsDidPayload = {
+            aid,
+            did: dws.dws,
+            didJsonUrl: dws.didJsonUrl,
+            keriCesrUrl: dws.keriCesrUrl,
+            updatedAt: new Date().toISOString(),
+        };
+        services.store.dispatch(didWebsDidLoaded(payload));
+        return payload;
+    } catch (error) {
+        services.store.dispatch(
+            didWebsDidFailed({
+                aid,
+                error: toErrorText(error),
+                updatedAt: new Date().toISOString(),
+            })
+        );
+        return null;
+    }
+}

--- a/tests/unit/contactsService.test.ts
+++ b/tests/unit/contactsService.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SignifyClient } from 'signify-ts';
+import { createAppRuntime } from '../../src/app/runtime';
+import {
+    generateIdentifierOobiService,
+    readIdentifierOobiService,
+    type OobiRole,
+} from '../../src/services/contacts.service';
+
+const jsonResponse = (body: unknown): Response =>
+    new Response(JSON.stringify(body), {
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+const makeClient = ({
+    oobis = ['http://127.0.0.1:3902/oobi/Eaid/agent/Eagent'],
+    existingEndRoles = [],
+}: {
+    oobis?: string[];
+    existingEndRoles?: unknown[];
+} = {}) => {
+    const operation = { name: 'endrole.alice.agent' };
+    const addEndRole = vi.fn(async () => ({
+        op: vi.fn(async () => operation),
+    }));
+    const fetch = vi.fn(async () => jsonResponse(existingEndRoles));
+    const getOobi = vi.fn(async (_identifier: string, _role: OobiRole) => ({
+        oobis,
+    }));
+    const wait = vi.fn(async () => ({
+        ...operation,
+        done: true,
+    }));
+    const client = {
+        agent: { pre: 'Eagent' },
+        fetch,
+        identifiers: () => ({ addEndRole }),
+        oobis: () => ({ get: getOobi }),
+        operations: () => ({ wait }),
+    } as unknown as SignifyClient;
+
+    return { addEndRole, client, fetch, getOobi, wait };
+};
+
+const runService = async <T>(service: () => Generator<unknown, T, unknown>) => {
+    const runtime = createAppRuntime({ storage: null });
+    try {
+        return await runtime.runWorkflow(service, {
+            scope: 'app',
+            track: false,
+        });
+    } finally {
+        await runtime.destroy();
+    }
+};
+
+describe('identifier OOBI services', () => {
+    it('reads available OOBIs without authorizing the agent end-role', async () => {
+        const { addEndRole, client, getOobi } = makeClient();
+
+        const record = await runService(() =>
+            readIdentifierOobiService({
+                client,
+                identifier: 'alice',
+                role: 'agent',
+            })
+        );
+
+        expect(record).toMatchObject({
+            id: 'alice:agent',
+            identifier: 'alice',
+            role: 'agent',
+            oobis: ['http://127.0.0.1:3902/oobi/Eaid/agent/Eagent'],
+        });
+        expect(getOobi).toHaveBeenCalledWith('alice', 'agent');
+        expect(addEndRole).not.toHaveBeenCalled();
+    });
+
+    it('treats empty read-only OOBI responses as unavailable state', async () => {
+        const { addEndRole, client } = makeClient({ oobis: [] });
+
+        const record = await runService(() =>
+            readIdentifierOobiService({
+                client,
+                identifier: 'alice',
+                role: 'agent',
+            })
+        );
+
+        expect(record).toBeNull();
+        expect(addEndRole).not.toHaveBeenCalled();
+    });
+
+    it('keeps generated agent OOBIs as the intentional authorization path', async () => {
+        const { addEndRole, client, wait } = makeClient();
+
+        const record = await runService(() =>
+            generateIdentifierOobiService({
+                client,
+                identifier: 'alice',
+                role: 'agent',
+            })
+        );
+
+        expect(record.role).toBe('agent');
+        expect(addEndRole).toHaveBeenCalledWith('alice', 'agent', 'Eagent');
+        expect(wait).toHaveBeenCalledOnce();
+    });
+});

--- a/tests/unit/didwebsComponents.test.tsx
+++ b/tests/unit/didwebsComponents.test.tsx
@@ -1,0 +1,92 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { didWebsAssetUrlsFromDid } from '../../src/domain/didwebs/didWebsUrls';
+import { DidWebsPublicationDetails } from '../../src/features/didwebs/DidWebsPublicationDetails';
+import type { DidWebsDidRecord } from '../../src/state/didwebs.slice';
+
+const readyRecord: DidWebsDidRecord = {
+    aid: 'Eaid',
+    loadState: 'ready',
+    did: 'did:webs:example.com:dws:Eaid',
+    didJsonUrl: null,
+    keriCesrUrl: null,
+    error: null,
+    updatedAt: '2026-04-29T00:00:00.000Z',
+};
+
+describe('did:webs URL derivation', () => {
+    it('derives local did:webs asset URLs with http', () => {
+        expect(
+            didWebsAssetUrlsFromDid('did:webs:127.0.0.1%3A3902:dws:Eaid')
+        ).toEqual({
+            didJsonUrl: 'http://127.0.0.1:3902/dws/Eaid/did.json',
+            keriCesrUrl: 'http://127.0.0.1:3902/dws/Eaid/keri.cesr',
+        });
+    });
+
+    it('derives non-local did:webs asset URLs with https', () => {
+        expect(
+            didWebsAssetUrlsFromDid('did:webs:example.com:dws:Eaid')
+        ).toEqual({
+            didJsonUrl: 'https://example.com/dws/Eaid/did.json',
+            keriCesrUrl: 'https://example.com/dws/Eaid/keri.cesr',
+        });
+    });
+});
+
+describe('did:webs DID details', () => {
+    it('renders pending values without copy actions before a DID is available', () => {
+        const markup = renderToStaticMarkup(
+            <DidWebsPublicationDetails
+                record={{
+                    ...readyRecord,
+                    loadState: 'pending',
+                    did: null,
+                }}
+                testIdPrefix="identifier"
+            />
+        );
+
+        expect(markup).toContain('...pending...');
+        expect(markup).toContain('pending');
+        expect(markup).not.toContain('aria-label="copy did:webs DID"');
+    });
+
+    it('renders ready did:webs values as copyable', () => {
+        const markup = renderToStaticMarkup(
+            <DidWebsPublicationDetails
+                record={readyRecord}
+                testIdPrefix="identifier"
+            />
+        );
+
+        expect(markup).toContain('did:webs:example.com:dws:Eaid');
+        expect(markup).toContain('https://example.com/dws/Eaid/did.json');
+        expect(markup).toContain('aria-label="copy did:webs DID"');
+        expect(markup).toContain('aria-label="copy did.json URL"');
+        expect(markup).toContain('aria-label="copy keri.cesr URL"');
+    });
+
+    it('renders KERIA-provided asset URLs before derived URL fallbacks', () => {
+        const markup = renderToStaticMarkup(
+            <DidWebsPublicationDetails
+                record={{
+                    ...readyRecord,
+                    didJsonUrl:
+                        'http://host.docker.internal:3902/dws/Eaid/did.json',
+                    keriCesrUrl:
+                        'http://host.docker.internal:3902/dws/Eaid/keri.cesr',
+                }}
+                testIdPrefix="identifier"
+            />
+        );
+
+        expect(markup).toContain(
+            'http://host.docker.internal:3902/dws/Eaid/did.json'
+        );
+        expect(markup).toContain(
+            'http://host.docker.internal:3902/dws/Eaid/keri.cesr'
+        );
+        expect(markup).not.toContain('https://example.com/dws/Eaid/did.json');
+    });
+});

--- a/tests/unit/didwebsEndpointGuard.test.ts
+++ b/tests/unit/didwebsEndpointGuard.test.ts
@@ -1,0 +1,34 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourceRoot = join(process.cwd(), 'src');
+const didWebsEndpointLiteral = /['"`]\/didwebs\//;
+
+const sourceFiles = (dir: string): string[] =>
+    readdirSync(dir).flatMap((entry) => {
+        const path = join(dir, entry);
+        const stat = statSync(path);
+        if (stat.isDirectory()) {
+            return sourceFiles(path);
+        }
+        return /\.(ts|tsx)$/.test(entry) ? [path] : [];
+    });
+
+describe('did:webs endpoint usage', () => {
+    it('does not call removed did:webs admin endpoints from app source', () => {
+        const forbidden = sourceFiles(sourceRoot).flatMap((path) => {
+            const text = readFileSync(path, 'utf8');
+            return text
+                .split('\n')
+                .map((line, index) => ({ line, index: index + 1 }))
+                .filter(({ line }) => didWebsEndpointLiteral.test(line))
+                .map(
+                    ({ line, index }) =>
+                        `${relative(process.cwd(), path)}:${index}: ${line.trim()}`
+                );
+        });
+
+        expect(forbidden).toEqual([]);
+    });
+});

--- a/tests/unit/didwebsState.test.ts
+++ b/tests/unit/didwebsState.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+    didWebsDidFailed,
+    didWebsDidLoaded,
+    didWebsDidLoading,
+} from '../../src/state/didwebs.slice';
+import { selectDidWebsDidByAid } from '../../src/state/selectors';
+import { createAppStore } from '../../src/state/store';
+
+describe('did:webs state', () => {
+    it('tracks loading, pending, ready, and error DID projections', () => {
+        const store = createAppStore();
+
+        store.dispatch(
+            didWebsDidLoading({
+                aid: 'Eaid',
+                updatedAt: '2026-04-29T00:00:00.000Z',
+            })
+        );
+        expect(selectDidWebsDidByAid('Eaid')(store.getState())).toMatchObject({
+            loadState: 'loading',
+            did: null,
+        });
+
+        store.dispatch(
+            didWebsDidLoaded({
+                aid: 'Eaid',
+                did: null,
+                didJsonUrl: null,
+                keriCesrUrl: null,
+                updatedAt: '2026-04-29T00:00:01.000Z',
+            })
+        );
+        expect(selectDidWebsDidByAid('Eaid')(store.getState())).toMatchObject({
+            loadState: 'pending',
+            did: null,
+            didJsonUrl: null,
+            keriCesrUrl: null,
+        });
+
+        store.dispatch(
+            didWebsDidLoaded({
+                aid: 'Eaid',
+                did: 'did:webs:example:dws:Eaid',
+                didJsonUrl: 'https://example/dws/Eaid/did.json',
+                keriCesrUrl: 'https://example/dws/Eaid/keri.cesr',
+                updatedAt: '2026-04-29T00:00:02.000Z',
+            })
+        );
+        expect(selectDidWebsDidByAid('Eaid')(store.getState())).toMatchObject({
+            loadState: 'ready',
+            did: 'did:webs:example:dws:Eaid',
+            didJsonUrl: 'https://example/dws/Eaid/did.json',
+            keriCesrUrl: 'https://example/dws/Eaid/keri.cesr',
+        });
+
+        store.dispatch(
+            didWebsDidFailed({
+                aid: 'Eaid',
+                error: 'network down',
+                updatedAt: '2026-04-29T00:00:03.000Z',
+            })
+        );
+        expect(selectDidWebsDidByAid('Eaid')(store.getState())).toMatchObject({
+            loadState: 'error',
+            error: 'network down',
+        });
+    });
+});

--- a/tests/unit/identifierComponents.test.tsx
+++ b/tests/unit/identifierComponents.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { IdentifierTable } from '../../src/features/identifiers/IdentifierTable';
+import type { IdentifierSummary } from '../../src/domain/identifiers/identifierTypes';
+
+const identifier = {
+    name: 'alice',
+    prefix: 'Ealice',
+} as IdentifierSummary;
+
+describe('identifier UI actions', () => {
+    it('renders copy-agent-OOBI without a separate authorize-agent action', () => {
+        const markup = renderToStaticMarkup(
+            <IdentifierTable
+                identifiers={[identifier]}
+                onSelect={vi.fn()}
+                onRotate={vi.fn()}
+                isRotateDisabled={() => false}
+                onCopyAgentOobi={vi.fn()}
+                agentOobiCopyStatus={{}}
+            />
+        );
+
+        expect(markup).toContain('aria-label="Copy agent OOBI for alice"');
+        expect(markup).not.toContain('aria-label="Authorize agent for alice"');
+    });
+});

--- a/tests/unit/identifiersService.test.ts
+++ b/tests/unit/identifiersService.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SignifyClient } from 'signify-ts';
+import { createAppRuntime } from '../../src/app/runtime';
+import { ensureAgentEndRoleService } from '../../src/services/identifiers.service';
+
+const jsonResponse = (body: unknown): Response =>
+    new Response(JSON.stringify(body), {
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+const makeClient = ({
+    agentPre = 'Eagent',
+    existingEndRoles = [],
+}: {
+    agentPre?: string | null;
+    existingEndRoles?: unknown[];
+} = {}) => {
+    const operation = { name: 'endrole.alice.agent' };
+    const fetch = vi.fn(async () => jsonResponse(existingEndRoles));
+    const op = vi.fn(async () => operation);
+    const addEndRole = vi.fn(async () => ({ op }));
+    const wait = vi.fn(async () => ({
+        ...operation,
+        done: true,
+    }));
+    const client = {
+        agent: agentPre === null ? undefined : { pre: agentPre },
+        fetch,
+        identifiers: () => ({ addEndRole }),
+        operations: () => ({ wait }),
+    } as unknown as SignifyClient;
+
+    return { addEndRole, client, fetch, op, wait };
+};
+
+const runEnsureAgentEndRole = async (client: SignifyClient): Promise<void> => {
+    const runtime = createAppRuntime({ storage: null });
+    try {
+        await runtime.runWorkflow(
+            () =>
+                ensureAgentEndRoleService({
+                    client,
+                    identifier: 'alice',
+                }),
+            { scope: 'app', track: false }
+        );
+    } finally {
+        await runtime.destroy();
+    }
+};
+
+describe('ensureAgentEndRoleService', () => {
+    it('returns without creating a duplicate end-role when the agent is already authorized', async () => {
+        const { addEndRole, client, fetch, wait } = makeClient({
+            existingEndRoles: [{ role: 'agent', eid: 'Eagent' }],
+        });
+
+        await expect(runEnsureAgentEndRole(client)).resolves.toBeUndefined();
+
+        expect(fetch).toHaveBeenCalledWith(
+            '/identifiers/alice/endroles/agent',
+            'GET',
+            null
+        );
+        expect(addEndRole).not.toHaveBeenCalled();
+        expect(wait).not.toHaveBeenCalled();
+    });
+
+    it('adds and waits for the agent end-role when it is missing', async () => {
+        const { addEndRole, client, op, wait } = makeClient();
+
+        await expect(runEnsureAgentEndRole(client)).resolves.toBeUndefined();
+
+        expect(addEndRole).toHaveBeenCalledWith('alice', 'agent', 'Eagent');
+        expect(op).toHaveBeenCalledOnce();
+        expect(wait).toHaveBeenCalledOnce();
+    });
+
+    it('fails clearly when the connected client has no agent AID', async () => {
+        const { addEndRole, client } = makeClient({ agentPre: null });
+
+        await expect(runEnsureAgentEndRole(client)).rejects.toThrow(
+            'Connected Signify client is missing its agent AID.'
+        );
+        expect(addEndRole).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/routeData.test.ts
+++ b/tests/unit/routeData.test.ts
@@ -71,6 +71,7 @@ type RuntimeOverrides = Partial<
     delegations?: Partial<RouteDataRuntime['delegations']>;
     credentials?: Partial<RouteDataRuntime['credentials']>;
     multisig?: Partial<RouteDataRuntime['multisig']>;
+    didwebs?: Partial<RouteDataRuntime['didwebs']>;
 };
 
 const makeRuntime = (overrides: RuntimeOverrides = {}): RouteDataRuntime => {
@@ -237,7 +238,8 @@ const makeRuntime = (overrides: RuntimeOverrides = {}): RouteDataRuntime => {
             startAcceptInteraction: vi.fn(() => ({
                 status: 'accepted',
                 requestId: 'accept-interaction-multisig-request-1',
-                operationRoute: '/operations/accept-interaction-multisig-request-1',
+                operationRoute:
+                    '/operations/accept-interaction-multisig-request-1',
             })),
             startRotateGroup: vi.fn(() => ({
                 status: 'accepted',
@@ -247,13 +249,17 @@ const makeRuntime = (overrides: RuntimeOverrides = {}): RouteDataRuntime => {
             startAcceptRotation: vi.fn(() => ({
                 status: 'accepted',
                 requestId: 'accept-rotation-multisig-request-1',
-                operationRoute: '/operations/accept-rotation-multisig-request-1',
+                operationRoute:
+                    '/operations/accept-rotation-multisig-request-1',
             })),
             startJoinRotation: vi.fn(() => ({
                 status: 'accepted',
                 requestId: 'join-rotation-multisig-request-1',
                 operationRoute: '/operations/join-rotation-multisig-request-1',
             })),
+        },
+        didwebs: {
+            refreshIdentifierDid: vi.fn(async () => null),
         },
     };
 
@@ -287,6 +293,10 @@ const makeRuntime = (overrides: RuntimeOverrides = {}): RouteDataRuntime => {
         multisig: {
             ...runtime.multisig,
             ...overrides.multisig,
+        },
+        didwebs: {
+            ...runtime.didwebs,
+            ...overrides.didwebs,
         },
     };
 };
@@ -359,6 +369,7 @@ describe('route loaders', () => {
             summary,
         });
         expect(runtime.refreshState).toHaveBeenCalledOnce();
+        expect(runtime.didwebs.refreshIdentifierDid).not.toHaveBeenCalled();
     });
 
     it('loads dashboard, session, and credential inventory through the runtime boundary', async () => {
@@ -367,12 +378,26 @@ describe('route loaders', () => {
         await expect(loadDashboard(runtime)).resolves.toEqual({
             status: 'ready',
         });
+        expect(runtime.refreshState).toHaveBeenCalledOnce();
         expect(runtime.identifiers.list).toHaveBeenCalledOnce();
+        expect(runtime.didwebs.refreshIdentifierDid).not.toHaveBeenCalled();
         expect(runtime.contacts.syncInventory).toHaveBeenCalledOnce();
         expect(runtime.credentials.syncKnownSchemas).toHaveBeenCalledOnce();
         expect(runtime.credentials.syncRegistries).toHaveBeenCalledOnce();
         expect(runtime.credentials.syncInventory).toHaveBeenCalledOnce();
         expect(runtime.credentials.syncIpexActivity).toHaveBeenCalledOnce();
+    });
+
+    it('keeps dashboard ready when state refresh fails', async () => {
+        const runtime = makeRuntime({
+            refreshState: vi.fn(async () => {
+                throw new Error('agent state unavailable');
+            }),
+        });
+
+        await expect(loadDashboard(runtime)).resolves.toEqual({
+            status: 'ready',
+        });
     });
 
     it('loads contact inventory through the runtime boundary', async () => {
@@ -408,10 +433,7 @@ describe('route loaders', () => {
                     multisigGroupDetailsFromIdentifier({
                         identifier,
                         membersResponse: {
-                            signing: [
-                                { prefix: 'Ealice' },
-                                { prefix: 'Ebob' },
-                            ],
+                            signing: [{ prefix: 'Ealice' }, { prefix: 'Ebob' }],
                             rotation: [
                                 { prefix: 'Ealice' },
                                 { prefix: 'Ebob' },

--- a/tests/unit/runtimeCommands.test.ts
+++ b/tests/unit/runtimeCommands.test.ts
@@ -13,6 +13,7 @@ import {
     type WorkflowRunOptions,
 } from '../../src/app/runtimeCommands';
 import { defaultIdentifierCreateDraft } from '../../src/domain/identifiers/identifierHelpers';
+import type { IdentifierSummary } from '../../src/domain/identifiers/identifierTypes';
 import { identifierListLoaded } from '../../src/state/identifiers.slice';
 import type { DelegationRequestNotification } from '../../src/state/notifications.slice';
 import { createAppStore } from '../../src/state/store';


### PR DESCRIPTION
Stack PR 2/8 for splitting #34.

Scope:
- Adds did:webs identifier projection and the endpoint-role surface without introducing W3C issuance or presentation behavior.

Base branch: split/pr34-01-runtime-test-foundation
Head branch: split/pr34-02-didwebs-projection

Validation performed on final stack:
- pnpm lint
- pnpm build
- pnpm unit:test
- w3c-crosswalk make local-seed
- w3c-crosswalk make local-test
- pnpm w3c:holder-presentation:smoke