### PR TITLE
refactor: improve credential UX foundations

### DIFF
--- a/src/app/NavigationDrawer.tsx
+++ b/src/app/NavigationDrawer.tsx
@@ -87,7 +87,7 @@ const navButtonSx = (active: boolean) => ({
 });
 
 const LOCAL_STATE_CLEAR_CONFIRMATION =
-    'Clear all saved local app state for every identifier? This removes operation history, app notifications, and dismissed exchange records stored in this browser.';
+    'Clear all saved local app state for every identifier? This removes operation history, app notifications, dismissed exchange records, and the saved selected identifier stored in this browser.';
 
 const ClearLocalStateIcon = () => (
     <ListItemIcon

--- a/src/app/runtime.ts
+++ b/src/app/runtime.ts
@@ -37,6 +37,12 @@ import {
     type AppStateStorage,
 } from '../state/persistence';
 import {
+    createBrowserWalletSelectionPersistenceStore,
+    installWalletSelectionPersistence,
+    rehydrateWalletSelection as rehydratePersistedWalletSelection,
+    type WalletSelectionPersistenceStore,
+} from '../state/walletSelectionPersistence';
+import {
     sessionConnected,
     sessionConnectionFailed,
     sessionConnecting,
@@ -44,6 +50,7 @@ import {
     sessionStateRefreshed,
 } from '../state/session.slice';
 import { appStore, type AppStore } from '../state/store';
+import { walletAidCleared } from '../state/walletSelection.slice';
 import {
     bootOrConnectOp,
     getSignifyStateOp,
@@ -134,6 +141,8 @@ export interface AppRuntimeOptions {
     logger?: OperationLogger;
     /** Optional persistence storage override; `null` disables persistence. */
     storage?: AppStateStorage | null;
+    /** Optional selected-wallet-AID persistence override; `null` disables it. */
+    walletSelectionStorage?: WalletSelectionPersistenceStore | null;
 }
 
 /**
@@ -235,11 +244,23 @@ export class AppRuntime {
     /** Optional storage override for tests; `undefined` means browser default. */
     private readonly storage: AppStateStorage | null | undefined;
 
+    /** IndexedDB-backed selected-wallet-AID storage. */
+    private readonly walletSelectionStorage: WalletSelectionPersistenceStore | null;
+
     /** Controller AID selecting the current persisted app-state bucket. */
     private currentControllerAid: string | null = null;
 
+    /** Controller AID currently allowed to save selected-wallet-AID changes. */
+    private currentWalletSelectionControllerAid: string | null = null;
+
+    /** Monotonic guard for async selected-wallet-AID rehydration. */
+    private walletSelectionHydrationToken = 0;
+
     /** Store subscription cleanup for controller-scoped persistence writes. */
     private readonly uninstallPersistence: () => void;
+
+    /** Store subscription cleanup for controller-scoped wallet selection writes. */
+    private readonly uninstallWalletSelectionPersistence: () => void;
 
     /**
      * Current runtime snapshot exposed to React and route functions.
@@ -285,11 +306,21 @@ export class AppRuntime {
 
         this.storage =
             options.storage === undefined ? undefined : options.storage;
+        this.walletSelectionStorage =
+            options.walletSelectionStorage === undefined
+                ? createBrowserWalletSelectionPersistenceStore()
+                : options.walletSelectionStorage;
         this.uninstallPersistence = installAppStatePersistence(
             this.store,
             () => this.currentControllerAid,
             this.storage
         );
+        this.uninstallWalletSelectionPersistence =
+            installWalletSelectionPersistence(
+                this.store,
+                () => this.currentWalletSelectionControllerAid,
+                this.walletSelectionStorage
+            );
     }
 
     /**
@@ -343,6 +374,10 @@ export class AppRuntime {
         config: SignifyClientConfig,
         options: WorkflowRunOptions = {}
     ): Promise<ConnectedSignifyClient | null> => {
+        this.flushPersistence();
+        this.currentControllerAid = null;
+        this.currentWalletSelectionControllerAid = null;
+        this.walletSelectionHydrationToken += 1;
         this.store.dispatch(sessionConnecting());
         this.setConnection({
             status: 'connecting',
@@ -407,9 +442,11 @@ export class AppRuntime {
         void this.stopLiveSync();
         this.flushPersistence();
         void this.scopes.haltSession();
+        this.currentControllerAid = null;
+        this.currentWalletSelectionControllerAid = null;
+        this.walletSelectionHydrationToken += 1;
         this.store.dispatch(sessionDisconnected());
         this.setConnection(idleConnection);
-        this.currentControllerAid = null;
     };
 
     /**
@@ -463,7 +500,10 @@ export class AppRuntime {
      */
     clearAllLocalState = (): number => {
         const previousControllerAid = this.currentControllerAid;
+        const previousWalletSelectionControllerAid =
+            this.currentWalletSelectionControllerAid;
         this.currentControllerAid = null;
+        this.currentWalletSelectionControllerAid = null;
         try {
             this.store.dispatch(
                 operationsRehydrated({
@@ -486,9 +526,13 @@ export class AppRuntime {
                     records: [],
                 })
             );
+            this.store.dispatch(walletAidCleared());
+            void this.walletSelectionStorage?.clearAll().catch(() => undefined);
             return clearAllPersistedAppStates(this.storage);
         } finally {
             this.currentControllerAid = previousControllerAid;
+            this.currentWalletSelectionControllerAid =
+                previousWalletSelectionControllerAid;
         }
     };
 
@@ -797,9 +841,12 @@ export class AppRuntime {
 
         await this.scopes.destroy();
         this.uninstallPersistence();
+        this.uninstallWalletSelectionPersistence();
+        this.currentControllerAid = null;
+        this.currentWalletSelectionControllerAid = null;
+        this.walletSelectionHydrationToken += 1;
         this.store.dispatch(sessionDisconnected());
         this.setConnection(idleConnection);
-        this.currentControllerAid = null;
     };
 
     /**
@@ -895,8 +942,43 @@ export class AppRuntime {
         // Persist under the old controller before loading a different bucket.
         this.flushPersistence();
         this.currentControllerAid = controllerAid;
+        this.currentWalletSelectionControllerAid = null;
+        this.walletSelectionHydrationToken += 1;
         if (controllerAid !== null) {
             rehydratePersistedAppState(this.store, controllerAid, this.storage);
+            void this.rehydrateWalletSelection(controllerAid);
+        }
+    };
+
+    /**
+     * Load the last selected wallet AID only after the controller bucket is known.
+     */
+    private rehydrateWalletSelection = async (
+        controllerAid: string
+    ): Promise<void> => {
+        const token = this.walletSelectionHydrationToken;
+        try {
+            await rehydratePersistedWalletSelection({
+                store: this.store,
+                controllerAid,
+                storage: this.walletSelectionStorage,
+                canApply: () =>
+                    this.currentControllerAid === controllerAid &&
+                    this.walletSelectionHydrationToken === token,
+            });
+        } finally {
+            if (
+                this.currentControllerAid === controllerAid &&
+                this.walletSelectionHydrationToken === token
+            ) {
+                this.currentWalletSelectionControllerAid = controllerAid;
+                void this.walletSelectionStorage
+                    ?.save(
+                        controllerAid,
+                        this.store.getState().walletSelection.selectedAid
+                    )
+                    .catch(() => undefined);
+            }
         }
     };
 

--- a/src/domain/credentials/credentialMappings.ts
+++ b/src/domain/credentials/credentialMappings.ts
@@ -6,6 +6,11 @@ import type {
     Schema,
 } from 'signify-ts';
 import type {
+    CredentialAcdcEdgeReference,
+    CredentialAcdcRecord,
+    CredentialChainGraphEdgeRecord,
+    CredentialChainGraphNodeRecord,
+    CredentialChainGraphRecord,
     CredentialAdmitNotification,
     CredentialExchangeNotificationReference,
     CredentialGrantNotification,
@@ -115,10 +120,55 @@ export const exchangeRoute = (exchange: unknown): string | null =>
 export const schemaText = (schema: Schema, key: string): string | null =>
     stringValue((schema as Record<string, unknown>)[key]);
 
+const schemaObjectBranch = (
+    value: Record<string, unknown>
+): Record<string, unknown> | null => {
+    const oneOf = value.oneOf;
+    if (!Array.isArray(oneOf)) {
+        return null;
+    }
+
+    for (const candidate of oneOf) {
+        if (
+            isRecord(candidate) &&
+            (candidate.type === 'object' || isRecord(candidate.properties))
+        ) {
+            return candidate;
+        }
+    }
+
+    return null;
+};
+
 /** Preserve schema rules as data without cloning the full schema payload. */
 export const schemaRules = (schema: Schema): Record<string, unknown> | null => {
     const rules = (schema as Record<string, unknown>).rules;
-    return isRecord(rules) ? rules : null;
+    if (isRecord(rules)) {
+        return rules;
+    }
+
+    const properties = schemaProperties(schema);
+    const acdcRules = properties?.r;
+    if (!isRecord(acdcRules)) {
+        return null;
+    }
+
+    const objectBranch = schemaObjectBranch(acdcRules);
+    if (objectBranch !== null) {
+        const ruleProperties = objectBranch.properties;
+        return isRecord(ruleProperties) ? ruleProperties : objectBranch;
+    }
+
+    const ruleProperties = acdcRules.properties;
+    return isRecord(ruleProperties) ? ruleProperties : acdcRules;
+};
+
+/** Preserve schema properties for generic ACDC data display. */
+export const schemaProperties = (
+    schema: Schema
+): Record<string, unknown> | null => {
+    const properties = (schema as Record<string, unknown>).properties;
+    return isRecord(properties) ? properties : null;
 };
 
 /**
@@ -134,17 +184,22 @@ export const schemaRecordFromKeriaSchema = ({
     said: string;
     oobi: string | null;
     updatedAt: string;
-}): SchemaRecord => ({
-    said,
-    oobi,
-    status: 'resolved',
-    title: schemaText(schema, 'title'),
-    description: schemaText(schema, 'description'),
-    version: schemaText(schema, 'version'),
-    rules: schemaRules(schema),
-    error: null,
-    updatedAt,
-});
+}): SchemaRecord => {
+    const properties = schemaProperties(schema);
+    return {
+        said,
+        oobi,
+        status: 'resolved',
+        title: schemaText(schema, 'title'),
+        description: schemaText(schema, 'description'),
+        credentialType: schemaText(schema, 'credentialType'),
+        version: schemaText(schema, 'version'),
+        ...(properties === null ? {} : { properties }),
+        rules: schemaRules(schema),
+        error: null,
+        updatedAt,
+    };
+};
 
 /** Read a string field from KERIA registry records. */
 export const registryString = (
@@ -192,12 +247,28 @@ export const credentialSad = (
     credential: CredentialResult
 ): Record<string, unknown> => requireRecord(credential.sad, 'Credential SAD');
 
+/** Return the embedded schema from a credential result when KERIA supplied it. */
+export const credentialSchema = (credential: CredentialResult): Schema | null => {
+    const schema = (credential as Record<string, unknown>).schema;
+    return isRecord(schema) ? (schema as Schema) : null;
+};
+
 const credentialSubject = (
     credential: CredentialResult
 ): Record<string, unknown> | null => {
     const sad = credentialSad(credential);
     return isRecord(sad.a) ? sad.a : null;
 };
+
+const credentialRegistryId = (
+    sad: Record<string, unknown>
+): string | null => recordString(sad, 'ri') ?? recordString(sad, 'rd');
+
+const credentialRules = (sad: Record<string, unknown>): unknown | null =>
+    sad.r === undefined ? null : sad.r;
+
+const credentialEdgeBlock = (sad: Record<string, unknown>): unknown | null =>
+    sad.e === undefined ? null : sad.e;
 
 /** Require the credential SAID from a KERIA credential result. */
 export const credentialSaid = (credential: CredentialResult): string => {
@@ -207,6 +278,87 @@ export const credentialSaid = (credential: CredentialResult): string => {
     }
 
     return said;
+};
+
+const isCredentialResult = (value: unknown): value is CredentialResult =>
+    isRecord(value) && isRecord(value.sad);
+
+/** Return recursive chained credentials from a KERIA credential result. */
+export const credentialChains = (
+    credential: CredentialResult
+): CredentialResult[] => {
+    const chains = (credential as Record<string, unknown>).chains;
+    return Array.isArray(chains) ? chains.filter(isCredentialResult) : [];
+};
+
+const edgeOperator = (
+    source: Record<string, unknown>,
+    inheritedOperator: string | null
+): string | null => recordString(source, 'o') ?? inheritedOperator;
+
+const edgeSaid = (source: Record<string, unknown>): string | null =>
+    recordString(source, 'n') ?? recordString(source, 'd');
+
+const collectEdgeReferences = ({
+    value,
+    prefix,
+    inheritedOperator,
+    refs,
+}: {
+    value: unknown;
+    prefix: string | null;
+    inheritedOperator: string | null;
+    refs: CredentialAcdcEdgeReference[];
+}) => {
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => {
+            collectEdgeReferences({
+                value: item,
+                prefix: prefix === null ? String(index) : `${prefix}.${index}`,
+                inheritedOperator,
+                refs,
+            });
+        });
+        return;
+    }
+
+    if (!isRecord(value)) {
+        return;
+    }
+
+    const groupOperator = recordString(value, 'o') ?? inheritedOperator;
+    for (const [key, source] of Object.entries(value)) {
+        if (key === 'd' || key === 'o') {
+            continue;
+        }
+
+        const label = prefix === null ? key : `${prefix}.${key}`;
+        if (!isRecord(source)) {
+            continue;
+        }
+
+        const said = edgeSaid(source);
+        refs.push({
+            label,
+            said,
+            operator: edgeOperator(source, groupOperator),
+            data: source,
+        });
+    }
+};
+
+/** Extract all source credential references from a raw ACDC edge block. */
+export const credentialEdgeReferences = (
+    sad: Record<string, unknown>
+): CredentialAcdcEdgeReference[] => {
+    const refs: CredentialAcdcEdgeReference[] = [];
+    collectEdgeReferences({
+        value: credentialEdgeBlock(sad),
+        prefix: null,
+        inheritedOperator: null,
+        refs,
+    });
+    return refs;
 };
 
 /**
@@ -250,6 +402,198 @@ export const statusFromCredentialState = (
     return admitted ? 'admitted' : 'issued';
 };
 
+const credentialStateFromResult = (
+    credential: CredentialResult
+): CredentialState | null => {
+    const status = (credential as Record<string, unknown>).status;
+    return isRecord(status) ? (status as CredentialState) : null;
+};
+
+/**
+ * Project a KERIA credential result into generic raw ACDC detail state.
+ */
+export const credentialAcdcRecordFromKeriaCredential = ({
+    credential,
+    status = null,
+    updatedAt = new Date().toISOString(),
+}: {
+    credential: CredentialResult;
+    status?: CredentialSummaryRecord['status'] | null;
+    updatedAt?: string;
+}): CredentialAcdcRecord => {
+    const sad = credentialSad(credential);
+    const subject = credentialSubject(credential);
+
+    return {
+        said: credentialSaid(credential),
+        schemaSaid: recordString(sad, 's'),
+        registryId: credentialRegistryId(sad),
+        issuerAid: recordString(sad, 'i'),
+        holderAid: subject === null ? null : recordString(subject, 'i'),
+        subject,
+        rules: credentialRules(sad),
+        edges: credentialEdgeReferences(sad),
+        status,
+        updatedAt,
+    };
+};
+
+/**
+ * Flatten one credential plus its recursive chained credentials, de-duping by SAID.
+ */
+export const flattenCredentialChain = (
+    credential: CredentialResult
+): CredentialResult[] => {
+    const bySaid = new Map<string, CredentialResult>();
+    const visit = (candidate: CredentialResult) => {
+        const said = credentialSaid(candidate);
+        if (bySaid.has(said)) {
+            return;
+        }
+
+        bySaid.set(said, candidate);
+        for (const chain of credentialChains(candidate)) {
+            visit(chain);
+        }
+    };
+
+    visit(credential);
+    return Array.from(bySaid.values());
+};
+
+const graphNodeFromAcdc = (
+    acdc: CredentialAcdcRecord
+): CredentialChainGraphNodeRecord => ({
+    said: acdc.said,
+    schemaSaid: acdc.schemaSaid,
+    issuerAid: acdc.issuerAid,
+    holderAid: acdc.holderAid,
+    unresolved: false,
+    depth: 0,
+});
+
+const unresolvedGraphNode = (
+    said: string
+): CredentialChainGraphNodeRecord => ({
+    said,
+    schemaSaid: null,
+    issuerAid: null,
+    holderAid: null,
+    unresolved: true,
+    depth: 0,
+});
+
+const assignGraphDepths = ({
+    rootSaid,
+    nodes,
+    edges,
+}: {
+    rootSaid: string;
+    nodes: Map<string, CredentialChainGraphNodeRecord>;
+    edges: readonly CredentialChainGraphEdgeRecord[];
+}) => {
+    const incomingByTarget = new Map<string, CredentialChainGraphEdgeRecord[]>();
+    for (const edge of edges) {
+        incomingByTarget.set(edge.to, [
+            ...(incomingByTarget.get(edge.to) ?? []),
+            edge,
+        ]);
+    }
+
+    const queue: Array<{ said: string; depth: number }> = [
+        { said: rootSaid, depth: 0 },
+    ];
+    const bestDepth = new Map<string, number>();
+    while (queue.length > 0) {
+        const current = queue.shift();
+        if (current === undefined) {
+            continue;
+        }
+
+        if (bestDepth.has(current.said)) {
+            continue;
+        }
+
+        bestDepth.set(current.said, current.depth);
+        const node = nodes.get(current.said);
+        if (node !== undefined) {
+            node.depth = current.depth;
+        }
+
+        for (const edge of incomingByTarget.get(current.said) ?? []) {
+            queue.push({ said: edge.from, depth: current.depth + 1 });
+        }
+    }
+};
+
+/**
+ * Normalize one root credential's source credentials into a visual DAG record.
+ */
+export const credentialChainGraphFromKeriaCredential = ({
+    credential,
+    updatedAt = new Date().toISOString(),
+}: {
+    credential: CredentialResult;
+    updatedAt?: string;
+}): CredentialChainGraphRecord => {
+    const rootSaid = credentialSaid(credential);
+    const credentials = flattenCredentialChain(credential);
+    const acdcs = credentials.map((item) =>
+        credentialAcdcRecordFromKeriaCredential({
+            credential: item,
+            status: statusFromCredentialState(
+                credentialStateFromResult(item),
+                false
+            ),
+            updatedAt,
+        })
+    );
+    const nodes = new Map<string, CredentialChainGraphNodeRecord>();
+    for (const acdc of acdcs) {
+        nodes.set(acdc.said, graphNodeFromAcdc(acdc));
+    }
+
+    const edges: CredentialChainGraphEdgeRecord[] = [];
+    const edgeIds = new Set<string>();
+    for (const acdc of acdcs) {
+        for (const ref of acdc.edges) {
+            if (ref.said === null) {
+                continue;
+            }
+
+            if (!nodes.has(ref.said)) {
+                nodes.set(ref.said, unresolvedGraphNode(ref.said));
+            }
+
+            const id = `${ref.said}->${acdc.said}:${ref.label}`;
+            if (edgeIds.has(id)) {
+                continue;
+            }
+
+            edgeIds.add(id);
+            edges.push({
+                id,
+                from: ref.said,
+                to: acdc.said,
+                label: ref.label,
+                operator: ref.operator,
+            });
+        }
+    }
+
+    assignGraphDepths({ rootSaid, nodes, edges });
+
+    return {
+        rootSaid,
+        nodes: Array.from(nodes.values()).sort(
+            (left, right) =>
+                right.depth - left.depth || left.said.localeCompare(right.said)
+        ),
+        edges,
+        updatedAt,
+    };
+};
+
 /**
  * Project a KERIA credential result into the app's credential summary record.
  *
@@ -291,7 +635,7 @@ export const credentialRecordFromKeriaCredential = ({
     return {
         said,
         schemaSaid,
-        registryId: recordString(sad, 'ri'),
+        registryId: credentialRegistryId(sad),
         issuerAid: recordString(sad, 'i'),
         holderAid: subject === null ? null : recordString(subject, 'i'),
         direction,

--- a/src/domain/credentials/credentialTypes.ts
+++ b/src/domain/credentials/credentialTypes.ts
@@ -47,6 +47,57 @@ export interface CredentialSummaryRecord {
     updatedAt: string;
 }
 
+/** Raw ACDC edge reference extracted from the credential `e` block. */
+export interface CredentialAcdcEdgeReference {
+    label: string;
+    said: string | null;
+    operator: string | null;
+    data: Record<string, unknown> | null;
+}
+
+/**
+ * Generic ACDC detail record for schemas without local typed projectors.
+ */
+export interface CredentialAcdcRecord {
+    said: string;
+    schemaSaid: string | null;
+    registryId: string | null;
+    issuerAid: string | null;
+    holderAid: string | null;
+    subject: Record<string, unknown> | null;
+    rules: unknown | null;
+    edges: CredentialAcdcEdgeReference[];
+    status: CredentialStatus | null;
+    updatedAt: string;
+}
+
+/** Node in the rendered ACDC source/dependency graph. */
+export interface CredentialChainGraphNodeRecord {
+    said: string;
+    schemaSaid: string | null;
+    issuerAid: string | null;
+    holderAid: string | null;
+    unresolved: boolean;
+    depth: number;
+}
+
+/** Directed source-to-dependent edge in an ACDC chain graph. */
+export interface CredentialChainGraphEdgeRecord {
+    id: string;
+    from: string;
+    to: string;
+    label: string;
+    operator: string | null;
+}
+
+/** Normalized chained ACDC DAG for one root credential. */
+export interface CredentialChainGraphRecord {
+    rootSaid: string;
+    nodes: CredentialChainGraphNodeRecord[];
+    edges: CredentialChainGraphEdgeRecord[];
+    updatedAt: string;
+}
+
 /** IPEX exchange activity linked to one credential. */
 export interface CredentialIpexActivityRecord {
     id: string;
@@ -78,10 +129,20 @@ export interface SchemaRecord {
     status: SchemaResolutionStatus;
     title: string | null;
     description: string | null;
+    credentialType: string | null;
     version: string | null;
+    properties?: Record<string, unknown> | null;
     rules?: Record<string, unknown> | null;
     error: string | null;
     updatedAt: string | null;
+}
+
+/** Credential inventory plus embedded schemas observed while loading credentials. */
+export interface CredentialInventorySnapshot {
+    credentials: CredentialSummaryRecord[];
+    acdcs: CredentialAcdcRecord[];
+    chainGraphs: CredentialChainGraphRecord[];
+    schemas: SchemaRecord[];
 }
 
 /** Lifecycle of a credential registry known to the local issuer role. */

--- a/src/features/credentials/CredentialAidOverviewRoute.tsx
+++ b/src/features/credentials/CredentialAidOverviewRoute.tsx
@@ -14,6 +14,7 @@ import { monoValueSx } from '../../app/consoleStyles';
 import { useAppSelector } from '../../state/hooks';
 import {
     selectCredentialGrantNotifications,
+    selectCredentialSchemas,
     selectHeldCredentials,
     selectIssueableCredentialTypeViews,
     selectIssuedCredentials,
@@ -49,6 +50,7 @@ export const CredentialAidOverviewRoute = () => {
     } = useCredentialsRouteContext();
     const navigate = useNavigate();
     const credentialTypes = useAppSelector(selectIssueableCredentialTypeViews);
+    const schemas = useAppSelector(selectCredentialSchemas);
     const issuedCredentials = useAppSelector(selectIssuedCredentials);
     const heldCredentials = useAppSelector(selectHeldCredentials);
     const grantNotifications = useAppSelector(selectCredentialGrantNotifications);
@@ -62,6 +64,9 @@ export const CredentialAidOverviewRoute = () => {
             credentialType.schemaSaid,
             credentialType,
         ])
+    );
+    const schemasBySaid = new Map(
+        schemas.map((schema) => [schema.said, schema])
     );
     const selectedAidHeldCredentials = heldCredentialsForAid(
         heldCredentials,
@@ -223,6 +228,7 @@ export const CredentialAidOverviewRoute = () => {
                         <WalletStackPreview
                             credentials={selectedAidHeldCredentials}
                             credentialTypesBySchema={credentialTypesBySchema}
+                            schemasBySaid={schemasBySaid}
                         />
                     </Stack>
                 </OverviewChoiceCard>

--- a/src/features/credentials/CredentialIssuerRoute.tsx
+++ b/src/features/credentials/CredentialIssuerRoute.tsx
@@ -19,6 +19,7 @@ import { abbreviateMiddle } from '../../domain/contacts/contactHelpers';
 import { useAppSelector } from '../../state/hooks';
 import {
     selectCredentialRegistries,
+    selectCredentialSchemas,
     selectIssueableCredentialTypeViews,
     selectIssuedCredentials,
 } from '../../state/selectors';
@@ -52,6 +53,7 @@ export const CredentialIssuerRoute = () => {
     } = useCredentialsRouteContext();
     const navigate = useNavigate();
     const credentialTypes = useAppSelector(selectIssueableCredentialTypeViews);
+    const schemas = useAppSelector(selectCredentialSchemas);
     const issuedCredentials = useAppSelector(selectIssuedCredentials);
     const registries = useAppSelector(selectCredentialRegistries);
 
@@ -70,6 +72,9 @@ export const CredentialIssuerRoute = () => {
             credentialType.schemaSaid,
             credentialType,
         ])
+    );
+    const schemasBySaid = new Map(
+        schemas.map((schema) => [schema.said, schema])
     );
     const issuerStats = issuerStatsForAid({
         aid: selectedIdentifier.prefix,
@@ -283,7 +288,8 @@ export const CredentialIssuerRoute = () => {
                                             <TableCell>
                                                 {schemaLabel(
                                                     credential.schemaSaid,
-                                                    credentialTypesBySchema
+                                                    credentialTypesBySchema,
+                                                    schemasBySaid
                                                 )}
                                             </TableCell>
                                             <TableCell>

--- a/src/features/credentials/CredentialIssuerTypePanels.tsx
+++ b/src/features/credentials/CredentialIssuerTypePanels.tsx
@@ -25,7 +25,10 @@ import {
     SEDI_VOTER_ISSUE_TEXT_FIELDS,
     type SediVoterIssueFormDraft,
 } from '../../domain/credentials/sediVoterId';
-import type { CredentialSummaryRecord } from '../../domain/credentials/credentialTypes';
+import type {
+    CredentialSummaryRecord,
+    SchemaRecord,
+} from '../../domain/credentials/credentialTypes';
 import type { IssueableCredentialTypeView } from '../../domain/credentials/credentialCatalog';
 import type { ContactRecord } from '../../state/contacts.slice';
 import type { CredentialRegistryTile } from './credentialViewModels';
@@ -331,11 +334,13 @@ export const IssuedCredentialsForTypePanel = ({
     credentials,
     actionRunning,
     credentialTypesBySchema,
+    schemasBySaid,
     onGrant,
 }: {
     credentials: readonly CredentialSummaryRecord[];
     actionRunning: boolean;
     credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>;
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
     onGrant: (credential: CredentialSummaryRecord) => void;
 }) => (
     <ConsolePanel
@@ -398,6 +403,7 @@ export const IssuedCredentialsForTypePanel = ({
                                 credentialTypesBySchema={
                                     credentialTypesBySchema
                                 }
+                                schemasBySaid={schemasBySaid}
                             />
                         </Stack>
                     </Box>

--- a/src/features/credentials/CredentialIssuerTypeRoute.tsx
+++ b/src/features/credentials/CredentialIssuerTypeRoute.tsx
@@ -19,6 +19,7 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
     selectContacts,
     selectCredentialRegistries,
+    selectCredentialSchemas,
     selectIssueableCredentialTypeViews,
     selectIssuedCredentials,
     selectSelectedWalletRegistry,
@@ -71,6 +72,7 @@ export const CredentialIssuerTypeRoute = () => {
     const dispatch = useAppDispatch();
     const contacts = useAppSelector(selectContacts);
     const credentialTypes = useAppSelector(selectIssueableCredentialTypeViews);
+    const schemas = useAppSelector(selectCredentialSchemas);
     const registries = useAppSelector(selectCredentialRegistries);
     const issuedCredentials = useAppSelector(selectIssuedCredentials);
     const walletSelectedRegistry = useAppSelector(selectSelectedWalletRegistry);
@@ -92,6 +94,9 @@ export const CredentialIssuerTypeRoute = () => {
             credentialType.schemaSaid,
             credentialType,
         ])
+    );
+    const schemasBySaid = new Map(
+        schemas.map((schema) => [schema.said, schema])
     );
     const resolvedHolderContacts = resolvedCredentialHolderContacts(contacts);
     const activeHolderContact =
@@ -350,6 +355,7 @@ export const CredentialIssuerTypeRoute = () => {
                 credentials={selectedTypeIssuedCredentials}
                 actionRunning={actionRunning}
                 credentialTypesBySchema={credentialTypesBySchema}
+                schemasBySaid={schemasBySaid}
                 onGrant={submitGrant}
             />
         </Stack>

--- a/src/features/credentials/CredentialShared.tsx
+++ b/src/features/credentials/CredentialShared.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 import { Box, FormControl, InputLabel, MenuItem, Select, Stack, Typography } from '@mui/material';
 import { StatusPill, TelemetryRow } from '../../app/Console';
 import { clickablePanelSx, monoValueSx } from '../../app/consoleStyles';
-import type { CredentialSummaryRecord } from '../../domain/credentials/credentialTypes';
+import type {
+    CredentialSummaryRecord,
+    SchemaRecord,
+} from '../../domain/credentials/credentialTypes';
 import type { IdentifierSummary } from '../../domain/identifiers/identifierTypes';
 import type { IssueableCredentialTypeView } from '../../domain/credentials/credentialCatalog';
 import { abbreviateMiddle } from '../../domain/contacts/contactHelpers';
@@ -17,15 +20,28 @@ import { aidLabel, schemaLabel, timestampText } from './credentialDisplay';
 export const CredentialRecordRows = ({
     credential,
     credentialTypesBySchema,
+    schemasBySaid = new Map(),
 }: {
     credential: CredentialSummaryRecord;
     credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>;
+    schemasBySaid?: ReadonlyMap<string, SchemaRecord>;
 }) => (
     <Stack spacing={0.5}>
         <TelemetryRow
             label="Type"
-            value={schemaLabel(credential.schemaSaid, credentialTypesBySchema)}
+            value={schemaLabel(
+                credential.schemaSaid,
+                credentialTypesBySchema,
+                schemasBySaid
+            )}
         />
+        {credential.schemaSaid !== null && (
+            <TelemetryRow
+                label="Schema SAID"
+                value={credential.schemaSaid}
+                mono
+            />
+        )}
         <TelemetryRow
             label="Credential"
             value={aidLabel(credential.said)}
@@ -95,9 +111,11 @@ export const AidSelector = ({
 export const WalletStackPreview = ({
     credentials,
     credentialTypesBySchema,
+    schemasBySaid = new Map(),
 }: {
     credentials: readonly CredentialSummaryRecord[];
     credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>;
+    schemasBySaid?: ReadonlyMap<string, SchemaRecord>;
 }) => {
     const previewCredentials = credentials.slice(0, 3);
 
@@ -146,7 +164,8 @@ export const WalletStackPreview = ({
                         <Typography sx={{ fontWeight: 800 }}>
                             {schemaLabel(
                                 credential.schemaSaid,
-                                credentialTypesBySchema
+                                credentialTypesBySchema,
+                                schemasBySaid
                             )}
                         </Typography>
                         <Typography

--- a/src/features/credentials/CredentialWalletPanels.tsx
+++ b/src/features/credentials/CredentialWalletPanels.tsx
@@ -1,7 +1,6 @@
 import {
     Box,
     Button,
-    Collapse,
     Stack,
     Typography,
 } from '@mui/material';
@@ -14,6 +13,7 @@ import type { IssueableCredentialTypeView } from '../../domain/credentials/crede
 import type {
     CredentialGrantNotification,
     CredentialSummaryRecord,
+    SchemaRecord,
 } from '../../domain/credentials/credentialTypes';
 import type { CredentialWalletStats } from './credentialViewModels';
 import {
@@ -21,7 +21,6 @@ import {
     schemaStatusTone,
     statusTone,
 } from './credentialDisplay';
-import { CredentialRecordRows } from './CredentialShared';
 
 /**
  * Holder-side credential type readiness panel.
@@ -182,11 +181,13 @@ export const InboundGrantsPanel = ({
     grants,
     actionRunning,
     credentialTypesBySchema,
+    schemasBySaid,
     onAdmit,
 }: {
     grants: readonly CredentialGrantNotification[];
     actionRunning: boolean;
     credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>;
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
     onAdmit: (notificationId: string, grantSaid: string) => void;
 }) => (
     <ConsolePanel title="Inbound grants">
@@ -226,7 +227,8 @@ export const InboundGrantsPanel = ({
                                             grant.attributes.fullName ??
                                                 schemaLabel(
                                                     grant.schemaSaid,
-                                                    credentialTypesBySchema
+                                                    credentialTypesBySchema,
+                                                    schemasBySaid
                                                 )
                                         )}
                                     </Typography>
@@ -261,18 +263,19 @@ export const InboundGrantsPanel = ({
 );
 
 /**
- * Holder-side admitted credential list with local expansion state owned by the route.
+ * Holder-side admitted credential list. Rows navigate to the full dashboard
+ * credential detail route.
  */
 export const HeldCredentialsPanel = ({
     credentials,
-    expandedCredentialSaid,
     credentialTypesBySchema,
-    onToggleCredential,
+    schemasBySaid,
+    onOpenCredential,
 }: {
     credentials: readonly CredentialSummaryRecord[];
-    expandedCredentialSaid: string;
     credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>;
-    onToggleCredential: (credentialSaid: string) => void;
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
+    onOpenCredential: (credentialSaid: string) => void;
 }) => (
     <ConsolePanel title="Held credentials">
         {credentials.length === 0 ? (
@@ -282,76 +285,59 @@ export const HeldCredentialsPanel = ({
             />
         ) : (
             <Stack spacing={1.5}>
-                {credentials.map((credential) => {
-                    const expanded = expandedCredentialSaid === credential.said;
-                    return (
-                        <Box
-                            key={credential.said}
-                            role="button"
-                            tabIndex={0}
-                            onClick={() => onToggleCredential(credential.said)}
-                            onKeyDown={(event) => {
-                                if (
-                                    event.key === 'Enter' ||
-                                    event.key === ' '
-                                ) {
-                                    event.preventDefault();
-                                    onToggleCredential(credential.said);
-                                }
-                            }}
-                            sx={[
-                                {
-                                    border: 1,
-                                    borderColor: expanded
-                                        ? 'primary.main'
-                                        : 'divider',
-                                    borderRadius: 1,
-                                    p: 1.5,
-                                    bgcolor: 'rgba(13, 23, 34, 0.72)',
-                                },
-                                clickablePanelSx,
-                            ]}
-                        >
-                            <Stack spacing={1}>
-                                <Stack
-                                    direction={{ xs: 'column', sm: 'row' }}
-                                    spacing={1}
-                                    sx={{
-                                        justifyContent: 'space-between',
-                                        alignItems: {
-                                            xs: 'stretch',
-                                            sm: 'center',
-                                        },
-                                    }}
-                                >
-                                    <Typography sx={{ fontWeight: 800 }}>
-                                        {schemaLabel(
-                                            credential.schemaSaid,
-                                            credentialTypesBySchema
-                                        )}
-                                    </Typography>
-                                    <StatusPill
-                                        label={credential.status}
-                                        tone={statusTone(credential.status)}
-                                    />
-                                </Stack>
-                                <Typography variant="body2" sx={monoValueSx}>
-                                    {abbreviateMiddle(credential.said, 28)}
+                {credentials.map((credential) => (
+                    <Box
+                        key={credential.said}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => onOpenCredential(credential.said)}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter' || event.key === ' ') {
+                                event.preventDefault();
+                                onOpenCredential(credential.said);
+                            }
+                        }}
+                        sx={[
+                            {
+                                border: 1,
+                                borderColor: 'divider',
+                                borderRadius: 1,
+                                p: 1.5,
+                                bgcolor: 'rgba(13, 23, 34, 0.72)',
+                            },
+                            clickablePanelSx,
+                        ]}
+                    >
+                        <Stack spacing={1}>
+                            <Stack
+                                direction={{ xs: 'column', sm: 'row' }}
+                                spacing={1}
+                                sx={{
+                                    justifyContent: 'space-between',
+                                    alignItems: {
+                                        xs: 'stretch',
+                                        sm: 'center',
+                                    },
+                                }}
+                            >
+                                <Typography sx={{ fontWeight: 800 }}>
+                                    {schemaLabel(
+                                        credential.schemaSaid,
+                                        credentialTypesBySchema,
+                                        schemasBySaid
+                                    )}
                                 </Typography>
-                                <Collapse in={expanded}>
-                                    <Box sx={{ pt: 1 }}>
-                                        <CredentialRecordRows
-                                            credential={credential}
-                                            credentialTypesBySchema={
-                                                credentialTypesBySchema
-                                            }
-                                        />
-                                    </Box>
-                                </Collapse>
+                                <StatusPill
+                                    label={credential.status}
+                                    tone={statusTone(credential.status)}
+                                />
                             </Stack>
-                        </Box>
-                    );
-                })}
+                            <Typography variant="body2" sx={monoValueSx}>
+                                {abbreviateMiddle(credential.said, 28)}
+                            </Typography>
+                        </Stack>
+                    </Box>
+                ))}
             </Stack>
         )}
     </ConsolePanel>

--- a/src/features/credentials/CredentialWalletRoute.tsx
+++ b/src/features/credentials/CredentialWalletRoute.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react';
 import { Box, Button, Stack } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../state/hooks';
 import {
     selectCredentialGrantNotifications,
     selectHeldCredentials,
     selectIssueableCredentialTypeViews,
+    selectCredentialSchemas,
 } from '../../state/selectors';
 import {
     grantsForAid,
@@ -26,9 +26,10 @@ import {
  * Wallet route for one selected local AID.
  *
  * This route owns holder-side schema readiness, inbound grant admission, and
- * held credential expansion state.
+ * held credential navigation.
  */
 export const CredentialWalletRoute = () => {
+    const navigate = useNavigate();
     const {
         actionRunning,
         selectedIdentifier,
@@ -36,9 +37,9 @@ export const CredentialWalletRoute = () => {
         submitCredentialForm,
     } = useCredentialsRouteContext();
     const credentialTypes = useAppSelector(selectIssueableCredentialTypeViews);
+    const schemas = useAppSelector(selectCredentialSchemas);
     const heldCredentials = useAppSelector(selectHeldCredentials);
     const grantNotifications = useAppSelector(selectCredentialGrantNotifications);
-    const [expandedCredentialSaid, setExpandedCredentialSaid] = useState('');
 
     if (selectedIdentifier === null) {
         return null;
@@ -49,6 +50,9 @@ export const CredentialWalletRoute = () => {
             credentialType.schemaSaid,
             credentialType,
         ])
+    );
+    const schemasBySaid = new Map(
+        schemas.map((schema) => [schema.said, schema])
     );
     const selectedAidHeldCredentials = heldCredentialsForAid(
         heldCredentials,
@@ -76,10 +80,8 @@ export const CredentialWalletRoute = () => {
         submitCredentialForm(formData);
     };
 
-    const toggleHeldCredential = (credentialSaid: string) => {
-        setExpandedCredentialSaid((current) =>
-            current === credentialSaid ? '' : credentialSaid
-        );
+    const openHeldCredential = (credentialSaid: string) => {
+        navigate(`/dashboard/credentials/${encodeURIComponent(credentialSaid)}`);
     };
 
     return (
@@ -109,13 +111,14 @@ export const CredentialWalletRoute = () => {
                 grants={selectedAidGrants}
                 actionRunning={actionRunning}
                 credentialTypesBySchema={credentialTypesBySchema}
+                schemasBySaid={schemasBySaid}
                 onAdmit={submitAdmit}
             />
             <HeldCredentialsPanel
                 credentials={selectedAidHeldCredentials}
-                expandedCredentialSaid={expandedCredentialSaid}
                 credentialTypesBySchema={credentialTypesBySchema}
-                onToggleCredential={toggleHeldCredential}
+                schemasBySaid={schemasBySaid}
+                onOpenCredential={openHeldCredential}
             />
         </Stack>
     );

--- a/src/features/credentials/CredentialsView.tsx
+++ b/src/features/credentials/CredentialsView.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-router-dom';
 import { ConnectionRequired } from '../../app/ConnectionRequired';
 import { ConsolePanel, EmptyState, PageHeader, StatusPill } from '../../app/Console';
+import { useAppRuntime } from '../../app/runtimeHooks';
 import type { CredentialActionData, CredentialsLoaderData } from '../../app/routeData';
 import type { IssueableCredentialTypeView } from '../../domain/credentials/credentialCatalog';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
@@ -58,25 +59,49 @@ const submitWithId = (fetcher: FormSubmitter, formData: FormData): void => {
 export const CredentialsView = () => {
     const loaderData = useLoaderData() as CredentialsLoaderData;
     const fetcher = useFetcher<CredentialActionData>();
+    const runtime = useAppRuntime();
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const { aid: aidParam } = useParams<{ aid?: string }>();
     const identifiers = useAppSelector(selectIdentifiers);
     const walletSelectedAid = useAppSelector(selectSelectedWalletAid);
     const actionRunning = fetcher.state !== 'idle';
-    const selectedAid = aidParam ?? '';
+    const selectedAid = aidParam ?? walletSelectedAid ?? '';
     const selectedIdentifier =
         identifiers.find((identifier) => identifier.prefix === selectedAid) ??
         null;
 
     useEffect(() => {
+        if (aidParam === undefined && walletSelectedAid !== null) {
+            navigate(credentialPath(walletSelectedAid), { replace: true });
+        }
+    }, [aidParam, navigate, walletSelectedAid]);
+
+    useEffect(() => {
         if (
+            aidParam !== undefined &&
             selectedIdentifier !== null &&
             walletSelectedAid !== selectedIdentifier.prefix
         ) {
             dispatch(walletAidSelected({ aid: selectedIdentifier.prefix }));
         }
-    }, [dispatch, selectedIdentifier, walletSelectedAid]);
+    }, [aidParam, dispatch, selectedIdentifier, walletSelectedAid]);
+
+    useEffect(() => {
+        if (selectedIdentifier === null) {
+            return undefined;
+        }
+
+        const controller = new AbortController();
+        void runtime.didwebs
+            .refreshIdentifierDid(selectedIdentifier.name, selectedIdentifier.prefix, {
+                signal: controller.signal,
+                track: false,
+            })
+            .catch(() => undefined);
+
+        return () => controller.abort();
+    }, [runtime, selectedIdentifier]);
 
     if (loaderData.status === 'blocked') {
         return <ConnectionRequired />;

--- a/src/features/credentials/credentialDisplay.ts
+++ b/src/features/credentials/credentialDisplay.ts
@@ -3,6 +3,7 @@ import { abbreviateMiddle } from '../../domain/contacts/contactHelpers';
 import type {
     CredentialSummaryRecord,
     RegistryRecord,
+    SchemaRecord,
 } from '../../domain/credentials/credentialTypes';
 import type { IssueableCredentialTypeView } from '../../domain/credentials/credentialCatalog';
 
@@ -75,13 +76,17 @@ export const walletPath = (aid: string): string => `${credentialPath(aid)}/walle
  */
 export const schemaLabel = (
     schemaSaid: string | null,
-    credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>
+    credentialTypesBySchema: ReadonlyMap<string, IssueableCredentialTypeView>,
+    schemasBySaid: ReadonlyMap<string, SchemaRecord> = new Map()
 ): string => {
     if (schemaSaid === null) {
         return 'Not available';
     }
 
+    const schema = schemasBySaid.get(schemaSaid);
     return (
+        schema?.title ??
+        schema?.credentialType ??
         credentialTypesBySchema.get(schemaSaid)?.label ??
         abbreviateMiddle(schemaSaid, 18)
     );

--- a/src/features/dashboard/DashboardDetailViews.tsx
+++ b/src/features/dashboard/DashboardDetailViews.tsx
@@ -1,10 +1,6 @@
-import type { ReactNode } from 'react';
 import {
     Box,
     Button,
-    List,
-    ListItem,
-    ListItemText,
     Stack,
     Table,
     TableBody,
@@ -15,17 +11,19 @@ import {
     Typography,
 } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
-import { ConsolePanel, EmptyState, PageHeader, StatusPill, TelemetryRow } from '../../app/Console';
-import { monoValueSx } from '../../app/consoleStyles';
+import {
+    ConsolePanel,
+    EmptyState,
+    PageHeader,
+    TelemetryRow,
+} from '../../app/Console';
 import { UI_SOUND_HOVER_VALUE } from '../../app/uiSound';
 import type { DashboardLoaderData } from '../../app/routeData';
 import type {
     CredentialSummaryRecord,
-    RegistryRecord,
     SchemaRecord,
 } from '../../domain/credentials/credentialTypes';
-import { schemaRuleViews } from './schemaRules';
-import type { AidAliases, CredentialActivityEntry } from './dashboardViewModels';
+import type { AidAliases } from './dashboardViewModels';
 import {
     AidValue,
     BackToDashboard,
@@ -33,21 +31,9 @@ import {
     CredentialTypeValue,
     DashboardWarning,
     DetailValue,
-    FullAidValue,
-    FullMonoValue,
 } from './DashboardShared';
-import {
-    credentialLedgerStatus,
-    credentialTypeLabel,
-    displayText,
-    registryDisplay,
-    schemaTitle,
-    timestampText,
-} from './dashboardDisplay';
+import { displayText, timestampText } from './dashboardDisplay';
 
-/**
- * Detail page for resolved credential schemas on the dashboard.
- */
 export const ResolvedSchemasDetail = ({
     loaderData,
     schemas,
@@ -106,28 +92,26 @@ export const ResolvedSchemasDetail = ({
                                     {schemas.map((schema) => (
                                         <TableRow key={schema.said}>
                                             <TableCell>
-                                                <Typography variant="body2">
-                                                    {schemaTitle(schema)}
+                                                <Typography
+                                                    sx={{ fontWeight: 800 }}
+                                                >
+                                                    {displayText(schema.title)}
                                                 </Typography>
-                                                {schema.description !== null && (
-                                                    <Typography
-                                                        variant="caption"
-                                                        color="text.secondary"
-                                                    >
-                                                        {schema.description}
-                                                    </Typography>
-                                                )}
+                                                <Typography
+                                                    variant="body2"
+                                                    color="text.secondary"
+                                                >
+                                                    {displayText(
+                                                        schema.credentialType
+                                                    )}
+                                                </Typography>
                                             </TableCell>
+                                            <TableCell>{schema.status}</TableCell>
                                             <TableCell>
-                                                <StatusPill
-                                                    label={schema.status}
-                                                    tone="success"
+                                                <CopyableAbbreviation
+                                                    value={schema.said}
+                                                    label="schema SAID"
                                                 />
-                                            </TableCell>
-                                            <TableCell>
-                                                <DetailValue mono>
-                                                    {schema.said}
-                                                </DetailValue>
                                             </TableCell>
                                             <TableCell>
                                                 <DetailValue mono>
@@ -138,7 +122,9 @@ export const ResolvedSchemasDetail = ({
                                                 {displayText(schema.version)}
                                             </TableCell>
                                             <TableCell>
-                                                {timestampText(schema.updatedAt)}
+                                                {timestampText(
+                                                    schema.updatedAt
+                                                )}
                                             </TableCell>
                                         </TableRow>
                                     ))}
@@ -163,33 +149,26 @@ export const ResolvedSchemasDetail = ({
                                     },
                                 }}
                             >
-                                <Stack
-                                    direction="row"
-                                    spacing={1}
-                                    sx={{
-                                        alignItems: 'center',
-                                        justifyContent: 'space-between',
-                                        gap: 1,
-                                        mb: 1,
-                                    }}
-                                >
-                                    <Typography variant="subtitle1">
-                                        {schemaTitle(schema)}
-                                    </Typography>
-                                    <StatusPill
-                                        label={schema.status}
-                                        tone="success"
-                                    />
-                                </Stack>
+                                <Typography sx={{ fontWeight: 800 }}>
+                                    {displayText(schema.title)}
+                                </Typography>
+                                <TelemetryRow label="Status" value={schema.status} />
                                 <TelemetryRow
                                     label="SAID"
-                                    value={schema.said}
-                                    mono
+                                    value={
+                                        <CopyableAbbreviation
+                                            value={schema.said}
+                                            label="schema SAID"
+                                        />
+                                    }
                                 />
                                 <TelemetryRow
-                                    label="OOBI URL"
-                                    value={displayText(schema.oobi)}
-                                    mono
+                                    label="OOBI"
+                                    value={
+                                        <DetailValue mono>
+                                            {displayText(schema.oobi)}
+                                        </DetailValue>
+                                    }
                                 />
                                 <TelemetryRow
                                     label="Version"
@@ -208,17 +187,16 @@ export const ResolvedSchemasDetail = ({
     </Box>
 );
 
-/**
- * Mobile credential rows for issued/held dashboard detail lists.
- */
 const CredentialDetailMobileRows = ({
     credentials,
+    schemasBySaid,
     aidAliases,
     onOpenCredential,
 }: {
     credentials: readonly CredentialSummaryRecord[];
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
     aidAliases: AidAliases;
-    onOpenCredential: (said: string) => void;
+    onOpenCredential: (credential: CredentialSummaryRecord) => void;
 }) => (
     <Stack spacing={1.5} sx={{ display: { xs: 'flex', md: 'none' } }}>
         {credentials.map((credential) => (
@@ -227,11 +205,11 @@ const CredentialDetailMobileRows = ({
                 role="button"
                 tabIndex={0}
                 data-ui-sound={UI_SOUND_HOVER_VALUE}
-                onClick={() => onOpenCredential(credential.said)}
+                onClick={() => onOpenCredential(credential)}
                 onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
                         event.preventDefault();
-                        onOpenCredential(credential.said);
+                        onOpenCredential(credential);
                     }
                 }}
                 sx={{
@@ -255,7 +233,10 @@ const CredentialDetailMobileRows = ({
                         mb: 1,
                     }}
                 >
-                    <CredentialTypeValue credential={credential} />
+                    <CredentialTypeValue
+                        credential={credential}
+                        schemasBySaid={schemasBySaid}
+                    />
                 </Stack>
                 <TelemetryRow
                     label="Credential SAID"
@@ -290,19 +271,18 @@ const CredentialDetailMobileRows = ({
     </Stack>
 );
 
-/**
- * Desktop credential table for issued/held dashboard detail lists.
- */
 const CredentialDetailTable = ({
     credentials,
+    schemasBySaid,
     aidAliases,
     kind,
     onOpenCredential,
 }: {
     credentials: readonly CredentialSummaryRecord[];
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
     aidAliases: AidAliases;
     kind: 'issued' | 'held';
-    onOpenCredential: (said: string) => void;
+    onOpenCredential: (credential: CredentialSummaryRecord) => void;
 }) => (
     <Box sx={{ display: { xs: 'none', md: 'block' } }}>
         <TableContainer>
@@ -326,17 +306,23 @@ const CredentialDetailTable = ({
                             role="button"
                             tabIndex={0}
                             data-ui-sound={UI_SOUND_HOVER_VALUE}
-                            onClick={() => onOpenCredential(credential.said)}
+                            onClick={() => onOpenCredential(credential)}
                             onKeyDown={(event) => {
-                                if (event.key === 'Enter' || event.key === ' ') {
+                                if (
+                                    event.key === 'Enter' ||
+                                    event.key === ' '
+                                ) {
                                     event.preventDefault();
-                                    onOpenCredential(credential.said);
+                                    onOpenCredential(credential);
                                 }
                             }}
                             sx={{ cursor: 'pointer' }}
                         >
                             <TableCell>
-                                <CredentialTypeValue credential={credential} />
+                                <CredentialTypeValue
+                                    credential={credential}
+                                    schemasBySaid={schemasBySaid}
+                                />
                             </TableCell>
                             <TableCell>
                                 <AidValue
@@ -365,21 +351,20 @@ const CredentialDetailTable = ({
     </Box>
 );
 
-/**
- * Dashboard detail page for issued or held credential inventories.
- */
 export const CredentialsDetail = ({
     loaderData,
     credentials,
+    schemasBySaid,
     aidAliases,
     kind,
     onOpenCredential,
 }: {
     loaderData: Exclude<DashboardLoaderData, { status: 'blocked' }>;
     credentials: readonly CredentialSummaryRecord[];
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
     aidAliases: AidAliases;
     kind: 'issued' | 'held';
-    onOpenCredential: (said: string) => void;
+    onOpenCredential: (credential: CredentialSummaryRecord) => void;
 }) => {
     const issued = kind === 'issued';
     const title = issued ? 'Issued Credentials' : 'Held Credentials';
@@ -426,382 +411,18 @@ export const CredentialsDetail = ({
                     <>
                         <CredentialDetailTable
                             credentials={credentials}
+                            schemasBySaid={schemasBySaid}
                             aidAliases={aidAliases}
                             kind={kind}
                             onOpenCredential={onOpenCredential}
                         />
                         <CredentialDetailMobileRows
                             credentials={credentials}
+                            schemasBySaid={schemasBySaid}
                             aidAliases={aidAliases}
                             onOpenCredential={onOpenCredential}
                         />
                     </>
-                )}
-            </ConsolePanel>
-        </Box>
-    );
-};
-
-/**
- * Tone-coded grant/admit activity marker for credential detail timelines.
- */
-const CredentialActivityPill = ({
-    entry,
-}: {
-    entry: CredentialActivityEntry;
-}) => {
-    const direction =
-        entry.direction === 'sent'
-            ? 'sent'
-            : entry.direction === 'received'
-              ? 'received'
-              : 'observed';
-    const kind = entry.kind === 'grant' ? 'grant' : 'admit';
-    return (
-        <StatusPill
-            label={`${direction} ${kind}`}
-            tone={entry.kind === 'admit' ? 'success' : 'info'}
-        />
-    );
-};
-
-/**
- * Domain data rows displayed only when the credential carries known attributes.
- */
-const credentialDataRows = (
-    credential: CredentialSummaryRecord
-): Array<{ label: string; value: ReactNode }> => {
-    if (credential.attributes === null) {
-        return [];
-    }
-
-    return [
-        { label: 'Subject AID', value: credential.attributes.i },
-        { label: 'Full name', value: credential.attributes.fullName },
-        { label: 'Voter ID', value: credential.attributes.voterId },
-        { label: 'Precinct ID', value: credential.attributes.precinctId },
-        { label: 'County', value: credential.attributes.county },
-        { label: 'Jurisdiction', value: credential.attributes.jurisdiction },
-        { label: 'Election ID', value: credential.attributes.electionId },
-        { label: 'Eligible', value: credential.attributes.eligible ? 'Yes' : 'No' },
-        { label: 'Expires', value: credential.attributes.expires },
-    ];
-};
-
-/**
- * Dashboard detail page for one credential, including registry and IPEX activity.
- */
-export const CredentialRecordDetail = ({
-    loaderData,
-    credential,
-    schema,
-    registriesById,
-    aidAliases,
-    activity,
-}: {
-    loaderData: Exclude<DashboardLoaderData, { status: 'blocked' }>;
-    credential: CredentialSummaryRecord | null;
-    schema: SchemaRecord | null;
-    registriesById: ReadonlyMap<string, RegistryRecord>;
-    aidAliases: AidAliases;
-    activity: readonly CredentialActivityEntry[];
-}) => {
-    if (credential === null) {
-        return (
-            <Box
-                sx={{ display: 'grid', gap: 2.5 }}
-                data-testid="dashboard-credential-detail"
-            >
-                <PageHeader
-                    eyebrow="Dashboard"
-                    title="Credential not found"
-                    actions={<BackToDashboard />}
-                />
-                {loaderData.status === 'error' && (
-                    <DashboardWarning message={loaderData.message} />
-                )}
-                <EmptyState
-                    title="No credential record"
-                    message="The credential is not present in this connected wallet's local inventory."
-                    action={
-                        <Button
-                            component={RouterLink}
-                            to="/dashboard/credentials/held"
-                            variant="contained"
-                            data-ui-sound={UI_SOUND_HOVER_VALUE}
-                        >
-                            Open Held Credentials
-                        </Button>
-                    }
-                />
-            </Box>
-        );
-    }
-
-    const ledgerStatus = credentialLedgerStatus(credential);
-    const dataRows = credentialDataRows(credential);
-    const schemaRules = schema?.rules ?? null;
-    const schemaRulesRows = schemaRuleViews(schemaRules);
-    const backPath =
-        credential.direction === 'issued'
-            ? '/dashboard/credentials/issued'
-            : '/dashboard/credentials/held';
-
-    return (
-        <Box
-            sx={{ display: 'grid', gap: 2.5 }}
-            data-testid="dashboard-credential-detail"
-        >
-            <PageHeader
-                eyebrow="Credential"
-                title={credentialTypeLabel(credential)}
-                summary={credential.said}
-                actions={
-                    <Button
-                        component={RouterLink}
-                        to={backPath}
-                        variant="outlined"
-                        data-ui-sound={UI_SOUND_HOVER_VALUE}
-                    >
-                        Back to {credential.direction === 'issued' ? 'Issued' : 'Held'}
-                    </Button>
-                }
-            />
-            {loaderData.status === 'error' && (
-                <DashboardWarning message={loaderData.message} />
-            )}
-            <Box
-                sx={{
-                    display: 'grid',
-                    gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr' },
-                    gap: 2,
-                }}
-            >
-                <ConsolePanel
-                    title="Credential"
-                    eyebrow="Inventory"
-                    actions={
-                        <StatusPill
-                            label={ledgerStatus.label}
-                            tone={ledgerStatus.tone}
-                        />
-                    }
-                >
-                    <Stack spacing={0.5}>
-                        <TelemetryRow
-                            label="Type"
-                            value={credentialTypeLabel(credential)}
-                        />
-                        <TelemetryRow
-                            label="Credential SAID"
-                            value={<FullMonoValue value={credential.said} />}
-                        />
-                        <TelemetryRow
-                            label="Schema SAID"
-                            value={
-                                credential.schemaSaid === null ? (
-                                    'Not available'
-                                ) : (
-                                    <FullMonoValue value={credential.schemaSaid} />
-                                )
-                            }
-                        />
-                        <TelemetryRow
-                            label="Issuer AID"
-                            value={
-                                <FullAidValue
-                                    aid={credential.issuerAid}
-                                    aliases={aidAliases}
-                                />
-                            }
-                        />
-                        <TelemetryRow
-                            label="Holder AID"
-                            value={
-                                <FullAidValue
-                                    aid={credential.holderAid}
-                                    aliases={aidAliases}
-                                />
-                            }
-                        />
-                        <TelemetryRow
-                            label="Registry"
-                            value={registryDisplay(credential, registriesById)}
-                            mono
-                        />
-                        <TelemetryRow
-                            label="Issued"
-                            value={timestampText(credential.issuedAt)}
-                        />
-                        {credential.revokedAt !== null && (
-                            <TelemetryRow
-                                label="Revoked"
-                                value={timestampText(credential.revokedAt)}
-                            />
-                        )}
-                        {credential.error !== null && (
-                            <TelemetryRow
-                                label="Error"
-                                value={credential.error}
-                            />
-                        )}
-                    </Stack>
-                </ConsolePanel>
-                <ConsolePanel title="Credential data" eyebrow="Subject">
-                    {dataRows.length === 0 ? (
-                        <EmptyState
-                            title="No decoded credential data"
-                            message="This credential does not match a supported local data mapper."
-                        />
-                    ) : (
-                        <Stack spacing={0.5}>
-                            {dataRows.map((row) => (
-                                <TelemetryRow
-                                    key={row.label}
-                                    label={row.label}
-                                    value={row.value}
-                                />
-                            ))}
-                        </Stack>
-                    )}
-                </ConsolePanel>
-            </Box>
-            <ConsolePanel title="Schema rules" eyebrow="ACDC">
-                {schemaRulesRows.length === 0 ? (
-                    <EmptyState
-                        title="No schema rules"
-                        message="The resolved schema does not include a top-level rules section."
-                    />
-                ) : (
-                    <TableContainer>
-                        <Table size="small" aria-label="Schema rules">
-                            <TableHead>
-                                <TableRow>
-                                    <TableCell>Name</TableCell>
-                                    <TableCell>Value</TableCell>
-                                </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {schemaRulesRows.map((rule) => (
-                                    <TableRow
-                                        key={rule.name}
-                                        data-testid={`schema-rule-${rule.name}`}
-                                    >
-                                        <TableCell
-                                            sx={{
-                                                width: { xs: '42%', md: '30%' },
-                                                verticalAlign: 'top',
-                                                ...monoValueSx,
-                                                overflowWrap: 'anywhere',
-                                            }}
-                                        >
-                                            {rule.name}
-                                        </TableCell>
-                                        <TableCell
-                                            sx={{
-                                                verticalAlign: 'top',
-                                                overflowWrap: 'anywhere',
-                                                whiteSpace: 'pre-wrap',
-                                            }}
-                                        >
-                                            {rule.value}
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                )}
-            </ConsolePanel>
-            <ConsolePanel title="Activity log" eyebrow="IPEX">
-                {activity.length === 0 ? (
-                    <EmptyState
-                        title="No credential activity"
-                        message="Grant and admit exchange activity will appear here when available."
-                    />
-                ) : (
-                    <List disablePadding>
-                        {activity.map((entry) => (
-                            <ListItem
-                                key={entry.id}
-                                disableGutters
-                                sx={{
-                                    alignItems: 'flex-start',
-                                    borderBottom: 1,
-                                    borderColor: 'divider',
-                                    py: 1.25,
-                                    '&:last-child': {
-                                        borderBottom: 0,
-                                    },
-                                }}
-                            >
-                                <ListItemText
-                                    primary={
-                                        <Stack
-                                            direction={{ xs: 'column', sm: 'row' }}
-                                            spacing={1}
-                                            sx={{
-                                                alignItems: {
-                                                    xs: 'flex-start',
-                                                    sm: 'center',
-                                                },
-                                                justifyContent: 'space-between',
-                                                gap: 1,
-                                            }}
-                                        >
-                                            <Stack
-                                                direction="row"
-                                                spacing={1}
-                                                sx={{
-                                                    alignItems: 'center',
-                                                    flexWrap: 'wrap',
-                                                }}
-                                            >
-                                                <Typography component="span">
-                                                    {entry.title}
-                                                </Typography>
-                                                <CredentialActivityPill
-                                                    entry={entry}
-                                                />
-                                            </Stack>
-                                            <Typography
-                                                variant="caption"
-                                                color="text.secondary"
-                                            >
-                                                {timestampText(entry.timestamp)}
-                                            </Typography>
-                                        </Stack>
-                                    }
-                                    secondary={
-                                        <Stack spacing={0.5} sx={{ mt: 0.75 }}>
-                                            <TelemetryRow
-                                                label="Exchange SAID"
-                                                value={<FullMonoValue value={entry.said} />}
-                                            />
-                                            <TelemetryRow
-                                                label="Sender"
-                                                value={
-                                                    <FullAidValue
-                                                        aid={entry.primaryAid}
-                                                        aliases={aidAliases}
-                                                    />
-                                                }
-                                            />
-                                            <TelemetryRow
-                                                label="Recipient"
-                                                value={
-                                                    <FullAidValue
-                                                        aid={entry.secondaryAid}
-                                                        aliases={aidAliases}
-                                                    />
-                                                }
-                                            />
-                                        </Stack>
-                                    }
-                                />
-                            </ListItem>
-                        ))}
-                    </List>
                 )}
             </ConsolePanel>
         </Box>

--- a/src/features/dashboard/DashboardOverview.tsx
+++ b/src/features/dashboard/DashboardOverview.tsx
@@ -93,7 +93,7 @@ const CredentialSubTile = ({
             border: 1,
             borderColor: 'divider',
             borderRadius: 1,
-            bgcolor: 'rgba(13, 23, 34, 0.72)',
+            bgcolor: 'background.paper',
             px: 1.25,
             py: 1,
             minWidth: 0,

--- a/src/features/dashboard/DashboardShared.tsx
+++ b/src/features/dashboard/DashboardShared.tsx
@@ -1,11 +1,15 @@
 import type { ReactNode } from 'react';
 import { Box, Button, Stack, Tooltip, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { Link as RouterLink } from 'react-router-dom';
 import { StatusPill } from '../../app/Console';
 import { monoValueSx } from '../../app/consoleStyles';
 import { UI_SOUND_HOVER_VALUE } from '../../app/uiSound';
 import { abbreviateMiddle } from '../../domain/contacts/contactHelpers';
-import type { CredentialSummaryRecord } from '../../domain/credentials/credentialTypes';
+import type {
+    CredentialSummaryRecord,
+    SchemaRecord,
+} from '../../domain/credentials/credentialTypes';
 import type { AidAliases } from './dashboardViewModels';
 import { credentialTypeLabel } from './dashboardDisplay';
 
@@ -130,12 +134,19 @@ export const FullAidValue = ({
  */
 export const CredentialTypeValue = ({
     credential,
+    schemasBySaid = new Map(),
 }: {
     credential: CredentialSummaryRecord;
+    schemasBySaid?: ReadonlyMap<string, SchemaRecord>;
 }) => (
     <Stack spacing={0.25} sx={{ minWidth: 0 }}>
         <Typography variant="body2" noWrap>
-            {credentialTypeLabel(credential)}
+            {credentialTypeLabel(
+                credential,
+                credential.schemaSaid === null
+                    ? null
+                    : (schemasBySaid.get(credential.schemaSaid) ?? null)
+            )}
         </Typography>
         {credential.schemaSaid !== null && (
             <CopyableAbbreviation
@@ -189,7 +200,7 @@ export const DashboardWarning = ({ message }: { message: string }) => (
             border: 1,
             borderColor: 'warning.main',
             borderRadius: 1,
-            bgcolor: 'rgba(255, 196, 87, 0.08)',
+            bgcolor: (theme) => alpha(theme.palette.warning.main, 0.08),
             px: 2,
             py: 1.25,
         }}

--- a/src/features/dashboard/DashboardView.tsx
+++ b/src/features/dashboard/DashboardView.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import {
+    Navigate,
     useLoaderData,
     useLocation,
     useNavigate,
@@ -11,10 +12,7 @@ import type { DashboardLoaderData } from '../../app/routeData';
 import { useAppSelector } from '../../state/hooks';
 import {
     selectContacts,
-    selectCredentialIpexActivity,
-    selectCredentialRegistries,
     selectDashboardCounts,
-    selectCredentialGrantNotifications,
     selectHeldCredentials,
     selectIdentifiers,
     selectIssuedCredentials,
@@ -27,17 +25,16 @@ import {
 } from '../../state/selectors';
 import { DashboardOverview } from './DashboardOverview';
 import {
-    CredentialRecordDetail,
     CredentialsDetail,
     ResolvedSchemasDetail,
 } from './DashboardDetailViews';
 import {
-    buildCredentialActivity,
     buildDashboardAidAliases,
-    buildDashboardRegistryMap,
-    credentialDetailPath,
+    canonicalCredentialWorkflowPath,
     dashboardModeForPath,
+    legacyDashboardCredentialRedirectPath,
 } from './dashboardViewModels';
+import type { CredentialSummaryRecord } from '../../domain/credentials/credentialTypes';
 
 /**
  * Route view that summarizes session health, activity, and credential inventory.
@@ -61,64 +58,21 @@ export const DashboardView = () => {
     const resolvedSchemas = useAppSelector(selectResolvedCredentialSchemas);
     const issuedCredentials = useAppSelector(selectIssuedCredentials);
     const heldCredentials = useAppSelector(selectHeldCredentials);
-    const grantNotifications = useAppSelector(
-        selectCredentialGrantNotifications
-    );
-    const selectedCredentialExchangeActivities = useAppSelector(
-        selectCredentialIpexActivity(credentialSaid)
-    );
-    const registries = useAppSelector(selectCredentialRegistries);
     const contacts = useAppSelector(selectContacts);
     const identifiers = useAppSelector(selectIdentifiers);
     const connection = runtimeSnapshot.connection;
     const connectionUrl =
         connection.status === 'connected' ? connection.client.url : null;
-    const registriesById = useMemo(
-        () => buildDashboardRegistryMap(registries),
-        [registries]
-    );
     const aidAliases = useMemo(
         () => buildDashboardAidAliases({ contacts, identifiers }),
         [contacts, identifiers]
     );
-    const credentials = useMemo(
-        () => [...issuedCredentials, ...heldCredentials],
-        [issuedCredentials, heldCredentials]
+    const schemasBySaid = useMemo(
+        () => new Map(resolvedSchemas.map((schema) => [schema.said, schema])),
+        [resolvedSchemas]
     );
-    const selectedCredential = useMemo(
-        () =>
-            credentials.find(
-                (credential) => credential.said === credentialSaid
-            ) ?? null,
-        [credentialSaid, credentials]
-    );
-    const selectedCredentialSchema = useMemo(
-        () =>
-            selectedCredential?.schemaSaid === null ||
-            selectedCredential?.schemaSaid === undefined
-                ? null
-                : (resolvedSchemas.find(
-                      (schema) => schema.said === selectedCredential.schemaSaid
-                  ) ?? null),
-        [resolvedSchemas, selectedCredential]
-    );
-    const selectedCredentialActivity = useMemo(
-        () =>
-            selectedCredential === null
-                ? []
-                : buildCredentialActivity({
-                      credential: selectedCredential,
-                      grantNotifications,
-                      exchangeActivities: selectedCredentialExchangeActivities,
-                  }),
-        [
-            grantNotifications,
-            selectedCredential,
-            selectedCredentialExchangeActivities,
-        ]
-    );
-    const openCredential = (said: string) => {
-        navigate(credentialDetailPath(said));
+    const openCredential = (credential: CredentialSummaryRecord) => {
+        navigate(canonicalCredentialWorkflowPath(credential) ?? '/credentials');
     };
 
     if (loaderData.status === 'blocked') {
@@ -141,6 +95,7 @@ export const DashboardView = () => {
             <CredentialsDetail
                 loaderData={loaderData}
                 credentials={issuedCredentials}
+                schemasBySaid={schemasBySaid}
                 aidAliases={aidAliases}
                 kind="issued"
                 onOpenCredential={openCredential}
@@ -153,6 +108,7 @@ export const DashboardView = () => {
             <CredentialsDetail
                 loaderData={loaderData}
                 credentials={heldCredentials}
+                schemasBySaid={schemasBySaid}
                 aidAliases={aidAliases}
                 kind="held"
                 onOpenCredential={openCredential}
@@ -162,13 +118,13 @@ export const DashboardView = () => {
 
     if (mode === 'credentialDetail') {
         return (
-            <CredentialRecordDetail
-                loaderData={loaderData}
-                credential={selectedCredential}
-                schema={selectedCredentialSchema}
-                registriesById={registriesById}
-                aidAliases={aidAliases}
-                activity={selectedCredentialActivity}
+            <Navigate
+                to={legacyDashboardCredentialRedirectPath({
+                    credentialSaid,
+                    heldCredentials,
+                    issuedCredentials,
+                })}
+                replace
             />
         );
     }

--- a/src/features/dashboard/credentialAcdcDisplay.ts
+++ b/src/features/dashboard/credentialAcdcDisplay.ts
@@ -1,0 +1,191 @@
+import type {
+    CredentialAcdcRecord,
+    CredentialChainGraphNodeRecord,
+    SchemaRecord,
+} from '../../domain/credentials/credentialTypes';
+import { credentialSchemaDisplayLabel } from './dashboardDisplay';
+import { schemaRuleViews, type SchemaRuleView } from './schemaRules';
+
+export interface CredentialDataRow {
+    name: string;
+    label: string;
+    value: string;
+    description: string | null;
+}
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const stringifyValue = (value: unknown): string => {
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+
+    if (value === null) {
+        return 'null';
+    }
+
+    return JSON.stringify(value, null, 2) ?? String(value);
+};
+
+const schemaSubjectProperties = (
+    schema: SchemaRecord | null
+): Record<string, unknown> | null => {
+    const properties = schema?.properties;
+    if (!isPlainRecord(properties)) {
+        return null;
+    }
+
+    const subject = properties.a;
+    if (isPlainRecord(subject) && isPlainRecord(subject.properties)) {
+        return subject.properties;
+    }
+
+    return properties;
+};
+
+const schemaMetadataForPath = (
+    schema: SchemaRecord | null,
+    path: string
+): Record<string, unknown> | null => {
+    const properties = schemaSubjectProperties(schema);
+    if (properties === null) {
+        return null;
+    }
+
+    const direct = properties[path];
+    if (isPlainRecord(direct)) {
+        return direct;
+    }
+
+    const leaf = path.split('.').at(-1);
+    if (leaf === undefined) {
+        return null;
+    }
+
+    const leafMetadata = properties[leaf];
+    return isPlainRecord(leafMetadata) ? leafMetadata : null;
+};
+
+const metadataText = (
+    metadata: Record<string, unknown> | null,
+    key: string
+): string | null => {
+    const value = metadata?.[key];
+    return typeof value === 'string' && value.trim().length > 0
+        ? value.trim()
+        : null;
+};
+
+const fallbackLabel = (path: string): string => {
+    if (path === 'd') {
+        return 'Subject SAID';
+    }
+
+    if (path === 'i') {
+        return 'Subject AID';
+    }
+
+    if (path === 'dt') {
+        return 'Issued at';
+    }
+
+    return path;
+};
+
+const flattenSubjectRows = ({
+    value,
+    path,
+    schema,
+    rows,
+}: {
+    value: unknown;
+    path: string;
+    schema: SchemaRecord | null;
+    rows: CredentialDataRow[];
+}) => {
+    if (isPlainRecord(value)) {
+        const entries = Object.entries(value);
+        if (entries.length === 0) {
+            rows.push({
+                name: path,
+                label: fallbackLabel(path),
+                value: '{}',
+                description: null,
+            });
+            return;
+        }
+
+        for (const [key, nested] of entries) {
+            flattenSubjectRows({
+                value: nested,
+                path: `${path}.${key}`,
+                schema,
+                rows,
+            });
+        }
+        return;
+    }
+
+    if (Array.isArray(value)) {
+        rows.push({
+            name: path,
+            label: fallbackLabel(path),
+            value: stringifyValue(value),
+            description: null,
+        });
+        return;
+    }
+
+    const metadata = schemaMetadataForPath(schema, path);
+    rows.push({
+        name: path,
+        label: metadataText(metadata, 'title') ?? fallbackLabel(path),
+        value: stringifyValue(value),
+        description: metadataText(metadata, 'description'),
+    });
+};
+
+/** Convert arbitrary ACDC subject data into inspectable display rows. */
+export const credentialSubjectDataRows = (
+    acdc: CredentialAcdcRecord | null,
+    schema: SchemaRecord | null
+): CredentialDataRow[] => {
+    if (acdc?.subject === null || acdc?.subject === undefined) {
+        return [];
+    }
+
+    const rows: CredentialDataRow[] = [];
+    for (const [key, value] of Object.entries(acdc.subject)) {
+        flattenSubjectRows({ value, path: key, schema, rows });
+    }
+    return rows;
+};
+
+/** Convert arbitrary ACDC credential rules into inspectable rows. */
+export const credentialRulesRows = (
+    acdc: CredentialAcdcRecord | null
+): SchemaRuleView[] => schemaRuleViews(acdc?.rules);
+
+export const credentialGraphNodeLabel = ({
+    node,
+    schemasBySaid,
+}: {
+    node: CredentialChainGraphNodeRecord;
+    schemasBySaid: ReadonlyMap<string, SchemaRecord>;
+}): string => {
+    if (node.unresolved) {
+        return 'Unresolved ACDC';
+    }
+
+    return credentialSchemaDisplayLabel(
+        node.schemaSaid,
+        node.schemaSaid === null
+            ? null
+            : (schemasBySaid.get(node.schemaSaid) ?? null)
+    );
+};

--- a/src/features/dashboard/dashboardDisplay.ts
+++ b/src/features/dashboard/dashboardDisplay.ts
@@ -1,5 +1,6 @@
 import { formatTimestamp } from '../../app/timeFormat';
 import { ISSUEABLE_CREDENTIAL_TYPES } from '../../config/credentialCatalog';
+import { abbreviateMiddle } from '../../domain/contacts/contactHelpers';
 import type {
     CredentialSummaryRecord,
     RegistryRecord,
@@ -28,22 +29,33 @@ const schemaTypeLabel = (schemaSaid: string | null | undefined): string => {
     return (
         ISSUEABLE_CREDENTIAL_TYPES.find(
             (type) => type.schemaSaid === schemaSaid
-        )?.label ?? 'Credential schema'
+        )?.label ?? abbreviateMiddle(schemaSaid, 18)
     );
 };
+
+/** Resolve schema metadata into the human-readable credential type label. */
+export const credentialSchemaDisplayLabel = (
+    schemaSaid: string | null,
+    schema: SchemaRecord | null = null
+): string =>
+    schema?.title ??
+    schema?.credentialType ??
+    schemaTypeLabel(schemaSaid);
 
 /**
  * Prefer the resolved schema title, then the catalog label, then a generic fallback.
  */
 export const schemaTitle = (schema: SchemaRecord): string =>
-    schema.title ?? schemaTypeLabel(schema.said);
+    credentialSchemaDisplayLabel(schema.said, schema);
 
 /**
  * Resolve a credential's schema SAID into the dashboard type label.
  */
 export const credentialTypeLabel = (
-    credential: CredentialSummaryRecord
-): string => schemaTypeLabel(credential.schemaSaid);
+    credential: CredentialSummaryRecord,
+    schema: SchemaRecord | null = null
+): string =>
+    credentialSchemaDisplayLabel(credential.schemaSaid, schema);
 
 /**
  * Collapse credential persistence facts into the ledger status shown in dashboard lists.

--- a/src/features/dashboard/dashboardViewModels.ts
+++ b/src/features/dashboard/dashboardViewModels.ts
@@ -6,6 +6,7 @@ import type {
     CredentialSummaryRecord,
     RegistryRecord,
 } from '../../domain/credentials/credentialTypes';
+import { issuerPath, walletPath } from '../credentials/credentialDisplay';
 
 /**
  * Dashboard sub-route modes derived from the current location.
@@ -59,11 +60,48 @@ export const dashboardModeForPath = (pathname: string): DashboardMode => {
     return 'overview';
 };
 
-/**
- * Build the stable dashboard credential detail route.
- */
-export const credentialDetailPath = (said: string): string =>
-    `/dashboard/credentials/${encodeURIComponent(said)}`;
+export const canonicalCredentialWorkflowPath = (
+    credential: CredentialSummaryRecord
+): string | null => {
+    if (credential.direction === 'held') {
+        return credential.holderAid === null
+            ? null
+            : walletPath(credential.holderAid);
+    }
+
+    return credential.issuerAid === null
+        ? null
+        : issuerPath(credential.issuerAid);
+};
+
+export const legacyDashboardCredentialRedirectPath = ({
+    credentialSaid,
+    heldCredentials,
+    issuedCredentials,
+}: {
+    credentialSaid: string;
+    heldCredentials: readonly CredentialSummaryRecord[];
+    issuedCredentials: readonly CredentialSummaryRecord[];
+}): string => {
+    const candidates = [
+        heldCredentials.find((credential) => credential.said === credentialSaid),
+        issuedCredentials.find(
+            (credential) => credential.said === credentialSaid
+        ),
+    ];
+
+    for (const credential of candidates) {
+        if (credential === undefined) {
+            continue;
+        }
+        const path = canonicalCredentialWorkflowPath(credential);
+        if (path !== null) {
+            return path;
+        }
+    }
+
+    return '/dashboard/credentials/held';
+};
 
 /**
  * Merge exchange activity and grant notification facts for one credential timeline.

--- a/src/features/dashboard/schemaRules.ts
+++ b/src/features/dashboard/schemaRules.ts
@@ -45,15 +45,19 @@ const flattenSchemaRuleEntries = (
 };
 
 export const schemaRuleViews = (
-    rules: Record<string, unknown> | null | undefined
+    rules: unknown | null | undefined
 ): SchemaRuleView[] => {
     if (rules === undefined || rules === null) {
         return [];
     }
 
     const rows: SchemaRuleView[] = [];
-    for (const [key, value] of Object.entries(rules)) {
-        flattenSchemaRuleEntries(value, key, rows);
+    if (isPlainRecord(rules)) {
+        for (const [key, value] of Object.entries(rules)) {
+            flattenSchemaRuleEntries(value, key, rows);
+        }
+    } else {
+        flattenSchemaRuleEntries(rules, 'rules', rows);
     }
     return rows;
 };

--- a/src/features/identifiers/IdentifierTable.tsx
+++ b/src/features/identifiers/IdentifierTable.tsx
@@ -33,6 +33,7 @@ import { UI_SOUND_HOVER_VALUE } from '../../app/uiSound';
  */
 export interface IdentifierTableProps {
     identifiers: readonly IdentifierSummary[];
+    selectedAid: string | null;
     onSelect: (identifier: IdentifierSummary) => void;
     onRotate: (name: string) => void;
     isRotateDisabled: (identifier: IdentifierSummary) => boolean;
@@ -138,6 +139,7 @@ const CopyableMonoValue = ({
  */
 export const IdentifierTable = ({
     identifiers,
+    selectedAid,
     onSelect,
     onRotate,
     isRotateDisabled,
@@ -175,100 +177,111 @@ export const IdentifierTable = ({
     return (
         <Box data-testid="identifier-table">
             <Stack spacing={1.5} sx={{ display: { xs: 'flex', sm: 'none' } }}>
-                {identifiers.map((identifier) => (
-                    <Card
-                        key={identifier.name}
-                        variant="outlined"
-                        data-testid={`identifier-row-${identifier.name}`}
-                        sx={{
-                            bgcolor: 'background.paper',
-                            borderColor: 'divider',
-                            '&:hover': {
-                                borderColor: 'primary.main',
-                            },
-                        }}
-                    >
-                        <CardContent>
-                            <Stack
-                                spacing={0.75}
-                                onClick={() => onSelect(identifier)}
-                                data-ui-sound={UI_SOUND_HOVER_VALUE}
-                                sx={{ cursor: 'pointer' }}
-                            >
-                                <Typography variant="subtitle1">
-                                    {identifier.name}
-                                </Typography>
-                                <Box>
-                                    <CopyableMonoValue
-                                        value={identifier.prefix}
-                                        label="full AID"
-                                        copied={
-                                            copiedValue === identifier.prefix
-                                        }
-                                        onCopy={copyValue}
-                                    />
-                                </Box>
-                                <Typography
-                                    variant="caption"
-                                    color="text.secondary"
-                                >
-                                    {identifierType(identifier)}
-                                </Typography>
-                                <Stack direction="row" spacing={2}>
-                                    <Typography
-                                        variant="caption"
-                                        color="text.secondary"
-                                    >
-                                        KIDX:{' '}
-                                        {formatIdentifierMetadata(
-                                            identifierKeyIndex(identifier)
-                                        )}
-                                    </Typography>
-                                    <Typography
-                                        variant="caption"
-                                        color="text.secondary"
-                                    >
-                                        PIDX:{' '}
-                                        {formatIdentifierMetadata(
-                                            identifierIdentifierIndex(
-                                                identifier
-                                            )
-                                        )}
-                                    </Typography>
-                                </Stack>
-                            </Stack>
-                        </CardContent>
-                        <CardActions
+                {identifiers.map((identifier) => {
+                    const selected = selectedAid === identifier.prefix;
+                    return (
+                        <Card
+                            key={identifier.name}
+                            variant="outlined"
+                            aria-selected={selected}
+                            data-testid={`identifier-row-${identifier.name}`}
                             sx={{
-                                justifyContent: 'flex-end',
-                                minHeight: 48,
-                                pt: 0,
-                                flexWrap: 'nowrap',
+                                bgcolor: selected
+                                    ? 'rgba(39, 215, 255, 0.08)'
+                                    : 'background.paper',
+                                borderColor: selected
+                                    ? 'primary.main'
+                                    : 'divider',
+                                '&:hover': {
+                                    borderColor: 'primary.main',
+                                },
                             }}
                         >
-                            <OobiCopyButton
-                                identifier={identifier}
-                                copyStatus={
-                                    agentOobiCopyStatus[identifier.name]
-                                }
-                                onCopy={copyAgentOobi}
-                            />
-                            <Tooltip title="Rotate identifier">
-                                <span>
-                                    <IconButton
-                                        aria-label={`Rotate identifier ${identifier.name}`}
-                                        disabled={isRotateDisabled(identifier)}
-                                        onClick={(event) =>
-                                            rotate(event, identifier)
-                                        }
+                            <CardContent>
+                                <Stack
+                                    spacing={0.75}
+                                    onClick={() => onSelect(identifier)}
+                                    data-ui-sound={UI_SOUND_HOVER_VALUE}
+                                    sx={{ cursor: 'pointer' }}
+                                >
+                                    <Typography variant="subtitle1">
+                                        {identifier.name}
+                                    </Typography>
+                                    <Box>
+                                        <CopyableMonoValue
+                                            value={identifier.prefix}
+                                            label="full AID"
+                                            copied={
+                                                copiedValue ===
+                                                identifier.prefix
+                                            }
+                                            onCopy={copyValue}
+                                        />
+                                    </Box>
+                                    <Typography
+                                        variant="caption"
+                                        color="text.secondary"
                                     >
-                                        <RotateRightIcon />
-                                    </IconButton>
-                                </span>
-                            </Tooltip>
-                        </CardActions>
-                    </Card>
-                ))}
+                                        {identifierType(identifier)}
+                                    </Typography>
+                                    <Stack direction="row" spacing={2}>
+                                        <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                        >
+                                            KIDX:{' '}
+                                            {formatIdentifierMetadata(
+                                                identifierKeyIndex(identifier)
+                                            )}
+                                        </Typography>
+                                        <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                        >
+                                            PIDX:{' '}
+                                            {formatIdentifierMetadata(
+                                                identifierIdentifierIndex(
+                                                    identifier
+                                                )
+                                            )}
+                                        </Typography>
+                                    </Stack>
+                                </Stack>
+                            </CardContent>
+                            <CardActions
+                                sx={{
+                                    justifyContent: 'flex-end',
+                                    minHeight: 48,
+                                    pt: 0,
+                                    flexWrap: 'nowrap',
+                                }}
+                            >
+                                <OobiCopyButton
+                                    identifier={identifier}
+                                    copyStatus={
+                                        agentOobiCopyStatus[identifier.name]
+                                    }
+                                    onCopy={copyAgentOobi}
+                                />
+                                <Tooltip title="Rotate identifier">
+                                    <span>
+                                        <IconButton
+                                            aria-label={`Rotate identifier ${identifier.name}`}
+                                            disabled={isRotateDisabled(
+                                                identifier
+                                            )}
+                                            onClick={(event) =>
+                                                rotate(event, identifier)
+                                            }
+                                        >
+                                            <RotateRightIcon />
+                                        </IconButton>
+                                    </span>
+                                </Tooltip>
+                            </CardActions>
+                        </Card>
+                    );
+                })}
             </Stack>
             <TableContainer
                 component={Paper}
@@ -330,122 +343,140 @@ export const IdentifierTable = ({
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {identifiers.map((identifier) => (
-                            <TableRow
-                                key={identifier.name}
-                                data-testid={`identifier-table-row-${identifier.name}`}
-                                data-ui-sound={UI_SOUND_HOVER_VALUE}
-                                sx={{
-                                    cursor: 'pointer',
-                                    '&:hover': {
-                                        bgcolor: 'action.hover',
-                                    },
-                                    '&:hover .identifier-actions-cell': {
-                                        bgcolor: 'rgba(39, 215, 255, 0.1)',
-                                    },
-                                    '&:last-child td, &:last-child th': {
-                                        border: 0,
-                                    },
-                                }}
-                                onClick={() => onSelect(identifier)}
-                            >
-                                <TableCell
-                                    component="th"
-                                    scope="row"
-                                    sx={{ minWidth: 0 }}
+                        {identifiers.map((identifier) => {
+                            const selected = selectedAid === identifier.prefix;
+                            return (
+                                <TableRow
+                                    key={identifier.name}
+                                    selected={selected}
+                                    aria-selected={selected}
+                                    data-testid={`identifier-table-row-${identifier.name}`}
+                                    data-ui-sound={UI_SOUND_HOVER_VALUE}
+                                    sx={{
+                                        cursor: 'pointer',
+                                        bgcolor: selected
+                                            ? 'rgba(39, 215, 255, 0.08)'
+                                            : undefined,
+                                        '&:hover': {
+                                            bgcolor: 'action.hover',
+                                        },
+                                        '&:hover .identifier-actions-cell': {
+                                            bgcolor: 'rgba(39, 215, 255, 0.1)',
+                                        },
+                                        '&:last-child td, &:last-child th': {
+                                            border: 0,
+                                        },
+                                    }}
+                                    onClick={() => onSelect(identifier)}
                                 >
-                                    <Typography
-                                        variant="body2"
+                                    <TableCell
+                                        component="th"
+                                        scope="row"
+                                        sx={{ minWidth: 0 }}
+                                    >
+                                        <Typography
+                                            variant="body2"
+                                            sx={{
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {identifier.name}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell sx={{ minWidth: 0 }}>
+                                        <CopyableMonoValue
+                                            value={identifier.prefix}
+                                            label="full AID"
+                                            copied={
+                                                copiedValue ===
+                                                identifier.prefix
+                                            }
+                                            onCopy={copyValue}
+                                        />
+                                    </TableCell>
+                                    <TableCell sx={mdUpCellSx}>
+                                        {identifierType(identifier)}
+                                    </TableCell>
+                                    <TableCell sx={lgUpCellSx}>
+                                        {formatIdentifierMetadata(
+                                            identifierKeyIndex(identifier)
+                                        )}
+                                    </TableCell>
+                                    <TableCell sx={lgUpCellSx}>
+                                        {formatIdentifierMetadata(
+                                            identifierIdentifierIndex(
+                                                identifier
+                                            )
+                                        )}
+                                    </TableCell>
+                                    <TableCell align="center" sx={lgUpCellSx}>
+                                        <OobiCopyButton
+                                            identifier={identifier}
+                                            copyStatus={
+                                                agentOobiCopyStatus[
+                                                    identifier.name
+                                                ]
+                                            }
+                                            onCopy={copyAgentOobi}
+                                        />
+                                    </TableCell>
+                                    <TableCell
+                                        align="right"
+                                        className="identifier-actions-cell"
                                         sx={{
-                                            overflow: 'hidden',
-                                            textOverflow: 'ellipsis',
-                                            whiteSpace: 'nowrap',
+                                            ...stickyActionCellSx,
+                                            bgcolor: selected
+                                                ? 'rgba(39, 215, 255, 0.08)'
+                                                : stickyActionCellSx.bgcolor,
                                         }}
                                     >
-                                        {identifier.name}
-                                    </Typography>
-                                </TableCell>
-                                <TableCell sx={{ minWidth: 0 }}>
-                                    <CopyableMonoValue
-                                        value={identifier.prefix}
-                                        label="full AID"
-                                        copied={
-                                            copiedValue === identifier.prefix
-                                        }
-                                        onCopy={copyValue}
-                                    />
-                                </TableCell>
-                                <TableCell sx={mdUpCellSx}>
-                                    {identifierType(identifier)}
-                                </TableCell>
-                                <TableCell sx={lgUpCellSx}>
-                                    {formatIdentifierMetadata(
-                                        identifierKeyIndex(identifier)
-                                    )}
-                                </TableCell>
-                                <TableCell sx={lgUpCellSx}>
-                                    {formatIdentifierMetadata(
-                                        identifierIdentifierIndex(identifier)
-                                    )}
-                                </TableCell>
-                                <TableCell align="center" sx={lgUpCellSx}>
-                                    <OobiCopyButton
-                                        identifier={identifier}
-                                        copyStatus={
-                                            agentOobiCopyStatus[identifier.name]
-                                        }
-                                        onCopy={copyAgentOobi}
-                                    />
-                                </TableCell>
-                                <TableCell
-                                    align="right"
-                                    className="identifier-actions-cell"
-                                    sx={stickyActionCellSx}
-                                >
-                                    <Stack
-                                        direction="row"
-                                        spacing={0.25}
-                                        sx={{
-                                            alignItems: 'center',
-                                            flexWrap: 'nowrap',
-                                            justifyContent: 'flex-end',
-                                        }}
-                                    >
-                                        <Box sx={compactOnlyActionSx}>
-                                            <OobiCopyButton
-                                                identifier={identifier}
-                                                copyStatus={
-                                                    agentOobiCopyStatus[
-                                                        identifier.name
-                                                    ]
-                                                }
-                                                onCopy={copyAgentOobi}
-                                                size="small"
-                                            />
-                                        </Box>
-                                        <Tooltip title="Rotate identifier">
-                                            <span>
-                                                <IconButton
-                                                    size="small"
-                                                    aria-label={`Rotate identifier ${identifier.name}`}
-                                                    disabled={isRotateDisabled(
-                                                        identifier
-                                                    )}
-                                                    onClick={(event) =>
-                                                        rotate(
-                                                            event,
-                                                            identifier
-                                                        )
+                                        <Stack
+                                            direction="row"
+                                            spacing={0.25}
+                                            sx={{
+                                                alignItems: 'center',
+                                                flexWrap: 'nowrap',
+                                                justifyContent: 'flex-end',
+                                            }}
+                                        >
+                                            <Box sx={compactOnlyActionSx}>
+                                                <OobiCopyButton
+                                                    identifier={identifier}
+                                                    copyStatus={
+                                                        agentOobiCopyStatus[
+                                                            identifier.name
+                                                        ]
                                                     }
-                                                >
-                                                    <RotateRightIcon fontSize="small" />
-                                                </IconButton>
-                                            </span>
-                                        </Tooltip>
-                                    </Stack>
-                                </TableCell>
-                            </TableRow>
-                        ))}
+                                                    onCopy={copyAgentOobi}
+                                                    size="small"
+                                                />
+                                            </Box>
+                                            <Tooltip title="Rotate identifier">
+                                                <span>
+                                                    <IconButton
+                                                        size="small"
+                                                        aria-label={`Rotate identifier ${identifier.name}`}
+                                                        disabled={isRotateDisabled(
+                                                            identifier
+                                                        )}
+                                                        onClick={(event) =>
+                                                            rotate(
+                                                                event,
+                                                                identifier
+                                                            )
+                                                        }
+                                                    >
+                                                        <RotateRightIcon fontSize="small" />
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                        </Stack>
+                                    </TableCell>
+                                </TableRow>
+                            );
+                        })}
                     </TableBody>
                 </Table>
             </TableContainer>

--- a/src/features/identifiers/IdentifiersView.tsx
+++ b/src/features/identifiers/IdentifiersView.tsx
@@ -33,6 +33,7 @@ import {
     selectContacts,
     selectDidWebsDidByAid,
     selectIdentifiers,
+    selectSelectedWalletAid,
 } from '../../state/selectors';
 import { walletAidSelected } from '../../state/walletSelection.slice';
 import {
@@ -81,6 +82,7 @@ export const IdentifiersView = () => {
     >({});
     const actionRunning = fetcher.state !== 'idle';
     const liveIdentifiers = useAppSelector(selectIdentifiers);
+    const selectedWalletAid = useAppSelector(selectSelectedWalletAid);
     const contacts = useAppSelector(selectContacts);
     const activeOperations = useAppSelector(selectActiveOperations);
     const activeResourceKeys = new Set(
@@ -456,6 +458,7 @@ export const IdentifiersView = () => {
             )}
             <IdentifierTable
                 identifiers={identifiers}
+                selectedAid={selectedWalletAid}
                 onSelect={handleSelectIdentifier}
                 onRotate={handleRotate}
                 isRotateDisabled={(identifier) =>

--- a/src/services/credentials.service.ts
+++ b/src/services/credentials.service.ts
@@ -10,8 +10,11 @@ import {
 import { callPromise, toErrorText } from '../effects/promise';
 import type { OperationLogger } from '../signify/client';
 import type {
+    CredentialInventorySnapshot,
     CredentialRegistryInventorySnapshot,
     CredentialRegistryOwner,
+    CredentialAcdcRecord,
+    CredentialChainGraphRecord,
     CredentialIpexActivityRecord,
     CredentialSummaryRecord,
     RegistryRecord,
@@ -21,8 +24,12 @@ import type { IssueableCredentialTypeRecord } from '../domain/credentials/creden
 import type { SediVoterCredentialAttributes } from '../domain/credentials/sediVoterId';
 import {
     credentialGrantFromExchange,
+    credentialAcdcRecordFromKeriaCredential,
+    credentialChainGraphFromKeriaCredential,
+    credentialChains,
     credentialRecordFromKeriaCredential,
     credentialSad,
+    credentialSchema,
     credentialSaid,
     exchangeExn,
     exchangeItemsFromResponse,
@@ -705,15 +712,76 @@ export function* listCredentialInventoryService({
 }: {
     client: SignifyClient;
     localAids: readonly string[];
-}): EffectionOperation<CredentialSummaryRecord[]> {
+}): EffectionOperation<CredentialInventorySnapshot> {
     const localAidSet = new Set(
         localAids.map((aid) => aid.trim()).filter((aid) => aid.length > 0)
     );
     if (localAidSet.size === 0) {
-        return [];
+        return { credentials: [], acdcs: [], chainGraphs: [], schemas: [] };
     }
 
     const records = new Map<string, CredentialSummaryRecord>();
+    const acdcs = new Map<string, CredentialAcdcRecord>();
+    const chainGraphs = new Map<string, CredentialChainGraphRecord>();
+    const schemas = new Map<string, SchemaRecord>();
+    const recordEmbeddedSchema = (credential: CredentialResult) => {
+        const sad = credentialSad(credential);
+        const schemaSaid = recordString(sad, 's');
+        const schema = credentialSchema(credential);
+        if (schemaSaid === null || schema === null) {
+            return;
+        }
+
+        schemas.set(
+            schemaSaid,
+            schemaRecordFromKeriaSchema({
+                schema,
+                said: schemaSaid,
+                oobi: null,
+                updatedAt: new Date().toISOString(),
+            })
+        );
+    };
+    const recordCredentialTree = ({
+        credential,
+        status,
+    }: {
+        credential: CredentialResult;
+        status: CredentialSummaryRecord['status'];
+    }) => {
+        const updatedAt = new Date().toISOString();
+        const pending = [credential];
+        const visited = new Set<string>();
+        while (pending.length > 0) {
+            const current = pending.shift();
+            if (current === undefined) {
+                continue;
+            }
+
+            const said = credentialSaid(current);
+            if (visited.has(said)) {
+                continue;
+            }
+
+            visited.add(said);
+            recordEmbeddedSchema(current);
+            acdcs.set(
+                said,
+                credentialAcdcRecordFromKeriaCredential({
+                    credential: current,
+                    status: current === credential ? status : null,
+                    updatedAt,
+                })
+            );
+            pending.push(...credentialChains(current));
+        }
+
+        chainGraphs.set(
+            credentialSaid(credential),
+            credentialChainGraphFromKeriaCredential({ credential, updatedAt })
+        );
+    };
+
     for (const localAid of localAidSet) {
         const issuedCredentials = yield* callPromise(() =>
             client.credentials().list({ filter: { '-i': localAid } })
@@ -721,7 +789,7 @@ export function* listCredentialInventoryService({
         for (const credential of issuedCredentials) {
             const said = credentialSaid(credential);
             const sad = credentialSad(credential);
-            const ri = recordString(sad, 'ri');
+            const ri = recordString(sad, 'ri') ?? recordString(sad, 'rd');
             let state: CredentialState | null = null;
             if (ri !== null) {
                 try {
@@ -732,6 +800,8 @@ export function* listCredentialInventoryService({
                     state = null;
                 }
             }
+            const status = statusFromCredentialState(state, false);
+            recordCredentialTree({ credential, status });
 
             records.set(
                 `issued:${said}`,
@@ -739,7 +809,7 @@ export function* listCredentialInventoryService({
                     credential,
                     credentialTypes: ISSUEABLE_CREDENTIAL_TYPES,
                     direction: 'issued',
-                    status: statusFromCredentialState(state, false),
+                    status,
                 })
             );
         }
@@ -750,7 +820,7 @@ export function* listCredentialInventoryService({
         for (const credential of heldCredentials) {
             const said = credentialSaid(credential);
             const sad = credentialSad(credential);
-            const ri = recordString(sad, 'ri');
+            const ri = recordString(sad, 'ri') ?? recordString(sad, 'rd');
             let state: CredentialState | null = null;
             if (ri !== null) {
                 try {
@@ -761,6 +831,8 @@ export function* listCredentialInventoryService({
                     state = null;
                 }
             }
+            const status = statusFromCredentialState(state, true);
+            recordCredentialTree({ credential, status });
 
             records.set(
                 `held:${said}`,
@@ -768,11 +840,16 @@ export function* listCredentialInventoryService({
                     credential,
                     credentialTypes: ISSUEABLE_CREDENTIAL_TYPES,
                     direction: 'held',
-                    status: statusFromCredentialState(state, true),
+                    status,
                 })
             );
         }
     }
 
-    return Array.from(records.values());
+    return {
+        credentials: Array.from(records.values()),
+        acdcs: Array.from(acdcs.values()),
+        chainGraphs: Array.from(chainGraphs.values()),
+        schemas: Array.from(schemas.values()),
+    };
 }

--- a/src/state/credentials.slice.ts
+++ b/src/state/credentials.slice.ts
@@ -5,6 +5,8 @@ import {
     sessionDisconnected,
 } from './session.slice';
 import type {
+    CredentialAcdcRecord,
+    CredentialChainGraphRecord,
     CredentialIpexActivityRecord,
     CredentialSummaryRecord,
 } from '../domain/credentials/credentialTypes';
@@ -18,6 +20,8 @@ import type {
 export interface CredentialsState {
     bySaid: Record<string, CredentialSummaryRecord>;
     saids: string[];
+    acdcBySaid: Record<string, CredentialAcdcRecord>;
+    chainGraphByRootSaid: Record<string, CredentialChainGraphRecord>;
     ipexActivityByCredentialSaid: Record<
         string,
         CredentialIpexActivityRecord[]
@@ -28,6 +32,8 @@ export interface CredentialsState {
 const createInitialState = (): CredentialsState => ({
     bySaid: {},
     saids: [],
+    acdcBySaid: {},
+    chainGraphByRootSaid: {},
     ipexActivityByCredentialSaid: {},
     ipexActivityLoadedAt: null,
 });
@@ -78,6 +84,8 @@ export const credentialsSlice = createSlice({
                 payload,
             }: PayloadAction<{
                 credentials: CredentialSummaryRecord[];
+                acdcs?: CredentialAcdcRecord[];
+                chainGraphs?: CredentialChainGraphRecord[];
             }>
         ) {
             for (const credential of payload.credentials) {
@@ -108,6 +116,14 @@ export const credentialsSlice = createSlice({
                 if (!state.saids.includes(credential.said)) {
                     state.saids.push(credential.said);
                 }
+            }
+
+            for (const acdc of payload.acdcs ?? []) {
+                state.acdcBySaid[acdc.said] = acdc;
+            }
+
+            for (const graph of payload.chainGraphs ?? []) {
+                state.chainGraphByRootSaid[graph.rootSaid] = graph;
             }
         },
         credentialIpexActivityLoaded(

--- a/src/state/schema.slice.ts
+++ b/src/state/schema.slice.ts
@@ -32,7 +32,15 @@ export const schemaSlice = createSlice({
     initialState,
     reducers: {
         schemaRecorded(state, { payload }: PayloadAction<SchemaRecord>) {
-            state.bySaid[payload.said] = payload;
+            const existing = state.bySaid[payload.said];
+            state.bySaid[payload.said] =
+                existing === undefined
+                    ? payload
+                    : {
+                          ...existing,
+                          ...payload,
+                          oobi: payload.oobi ?? existing.oobi,
+                      };
             if (!state.saids.includes(payload.said)) {
                 state.saids.push(payload.said);
             }

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -221,6 +221,22 @@ export const selectContactsByOobi = (state: RootState) => {
 export const selectCredentialStatus = (said: string) => (state: RootState) =>
     state.credentials.bySaid[said]?.status ?? null;
 
+/** Select one generic raw ACDC detail record by credential SAID. */
+export const selectCredentialAcdc =
+    (said: string) =>
+    (state: RootState) =>
+        state.credentials.acdcBySaid[said] ?? null;
+
+/** Select all generic raw ACDC detail records keyed by credential SAID. */
+export const selectCredentialAcdcsBySaid = (state: RootState) =>
+    state.credentials.acdcBySaid;
+
+/** Select the normalized chained ACDC DAG for one root credential SAID. */
+export const selectCredentialChainGraph =
+    (rootSaid: string) =>
+    (state: RootState) =>
+        state.credentials.chainGraphByRootSaid[rootSaid] ?? null;
+
 /** Select credential records newest first. */
 export const selectCredentials = (state: RootState) =>
     state.credentials.saids

--- a/src/state/walletSelectionPersistence.ts
+++ b/src/state/walletSelectionPersistence.ts
@@ -1,0 +1,242 @@
+import { walletAidSelected } from './walletSelection.slice';
+import type { AppStore } from './store';
+
+const WALLET_SELECTION_VERSION = 1;
+const WALLET_SELECTION_DB_NAME = 'signify-react-ts-wallet-selection';
+const WALLET_SELECTION_STORE_NAME = 'walletSelection';
+
+export interface PersistedWalletSelection {
+    version: typeof WALLET_SELECTION_VERSION;
+    controllerAid: string;
+    selectedAid: string | null;
+    updatedAt: string;
+}
+
+export interface WalletSelectionPersistenceStore {
+    load(controllerAid: string): Promise<PersistedWalletSelection | null>;
+    save(controllerAid: string, selectedAid: string | null): Promise<void>;
+    clearAll(): Promise<number>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null;
+
+const normalizeAid = (aid: string | null): string | null => {
+    const normalized = aid?.trim() ?? '';
+    return normalized.length === 0 ? null : normalized;
+};
+
+const isPersistedWalletSelection = (
+    value: unknown
+): value is PersistedWalletSelection =>
+    isRecord(value) &&
+    value.version === WALLET_SELECTION_VERSION &&
+    typeof value.controllerAid === 'string' &&
+    typeof value.updatedAt === 'string' &&
+    (value.selectedAid === null || typeof value.selectedAid === 'string');
+
+export class MemoryWalletSelectionPersistenceStore
+    implements WalletSelectionPersistenceStore
+{
+    private readonly records = new Map<string, PersistedWalletSelection>();
+
+    async load(controllerAid: string): Promise<PersistedWalletSelection | null> {
+        return this.records.get(controllerAid) ?? null;
+    }
+
+    async save(controllerAid: string, selectedAid: string | null): Promise<void> {
+        this.records.set(controllerAid, {
+            version: WALLET_SELECTION_VERSION,
+            controllerAid,
+            selectedAid: normalizeAid(selectedAid),
+            updatedAt: new Date().toISOString(),
+        });
+    }
+
+    async clearAll(): Promise<number> {
+        const count = this.records.size;
+        this.records.clear();
+        return count;
+    }
+}
+
+const requestPromise = <T>(request: IDBRequest<T>): Promise<T> =>
+    new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () =>
+            reject(request.error ?? new Error('IndexedDB request failed.'));
+    });
+
+const transactionComplete = (transaction: IDBTransaction): Promise<void> =>
+    new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () =>
+            reject(
+                transaction.error ?? new Error('IndexedDB transaction failed.')
+            );
+        transaction.onabort = () =>
+            reject(
+                transaction.error ?? new Error('IndexedDB transaction aborted.')
+            );
+    });
+
+export class IndexedDbWalletSelectionPersistenceStore
+    implements WalletSelectionPersistenceStore
+{
+    constructor(private readonly factory: IDBFactory) {}
+
+    async load(controllerAid: string): Promise<PersistedWalletSelection | null> {
+        const db = await this.openDb();
+        try {
+            const transaction = db.transaction(
+                WALLET_SELECTION_STORE_NAME,
+                'readonly'
+            );
+            const done = transactionComplete(transaction);
+            const store = transaction.objectStore(WALLET_SELECTION_STORE_NAME);
+            const record = await requestPromise(store.get(controllerAid));
+            await done;
+            return isPersistedWalletSelection(record) ? record : null;
+        } finally {
+            db.close();
+        }
+    }
+
+    async save(controllerAid: string, selectedAid: string | null): Promise<void> {
+        const db = await this.openDb();
+        try {
+            const transaction = db.transaction(
+                WALLET_SELECTION_STORE_NAME,
+                'readwrite'
+            );
+            const done = transactionComplete(transaction);
+            const store = transaction.objectStore(WALLET_SELECTION_STORE_NAME);
+            store.put({
+                version: WALLET_SELECTION_VERSION,
+                controllerAid,
+                selectedAid: normalizeAid(selectedAid),
+                updatedAt: new Date().toISOString(),
+            } satisfies PersistedWalletSelection);
+            await done;
+        } finally {
+            db.close();
+        }
+    }
+
+    async clearAll(): Promise<number> {
+        const db = await this.openDb();
+        try {
+            const transaction = db.transaction(
+                WALLET_SELECTION_STORE_NAME,
+                'readwrite'
+            );
+            const done = transactionComplete(transaction);
+            const store = transaction.objectStore(WALLET_SELECTION_STORE_NAME);
+            const countRequest = store.count();
+            store.clear();
+            const count = await requestPromise(countRequest);
+            await done;
+            return count;
+        } finally {
+            db.close();
+        }
+    }
+
+    private openDb(): Promise<IDBDatabase> {
+        return new Promise((resolve, reject) => {
+            const request = this.factory.open(WALLET_SELECTION_DB_NAME, 1);
+            request.onupgradeneeded = () => {
+                const db = request.result;
+                if (!db.objectStoreNames.contains(WALLET_SELECTION_STORE_NAME)) {
+                    db.createObjectStore(WALLET_SELECTION_STORE_NAME, {
+                        keyPath: 'controllerAid',
+                    });
+                }
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () =>
+                reject(request.error ?? new Error('Unable to open IndexedDB.'));
+        });
+    }
+}
+
+export const createBrowserWalletSelectionPersistenceStore =
+    (): WalletSelectionPersistenceStore => {
+        try {
+            const factory = globalThis.indexedDB;
+            if (factory !== undefined) {
+                return new IndexedDbWalletSelectionPersistenceStore(factory);
+            }
+        } catch {
+            // Fall through to session-only storage below.
+        }
+
+        return new MemoryWalletSelectionPersistenceStore();
+    };
+
+export const installWalletSelectionPersistence = (
+    store: AppStore,
+    controllerAid: () => string | null,
+    storage: WalletSelectionPersistenceStore | null
+): (() => void) => {
+    if (storage === null) {
+        return () => undefined;
+    }
+
+    let lastControllerAid: string | null = null;
+    let lastSelectedAid: string | null | undefined;
+
+    return store.subscribe(() => {
+        const currentControllerAid = controllerAid();
+        if (currentControllerAid === null) {
+            lastControllerAid = null;
+            lastSelectedAid = undefined;
+            return;
+        }
+
+        const selectedAid = store.getState().walletSelection.selectedAid;
+        if (
+            lastControllerAid === currentControllerAid &&
+            lastSelectedAid === selectedAid
+        ) {
+            return;
+        }
+
+        lastControllerAid = currentControllerAid;
+        lastSelectedAid = selectedAid;
+        void storage.save(currentControllerAid, selectedAid).catch(() => {
+            // Selection persistence is a convenience; the active session keeps working.
+        });
+    });
+};
+
+export const rehydrateWalletSelection = async ({
+    store,
+    controllerAid,
+    storage,
+    canApply,
+}: {
+    store: AppStore;
+    controllerAid: string;
+    storage: WalletSelectionPersistenceStore | null;
+    canApply: () => boolean;
+}): Promise<void> => {
+    if (storage === null) {
+        return;
+    }
+
+    const selectedAtStart = store.getState().walletSelection.selectedAid;
+    const record = await storage.load(controllerAid);
+    if (!canApply()) {
+        return;
+    }
+
+    const selectedNow = store.getState().walletSelection.selectedAid;
+    if (
+        record?.selectedAid !== null &&
+        record?.selectedAid !== undefined &&
+        selectedNow === selectedAtStart
+    ) {
+        store.dispatch(walletAidSelected({ aid: record.selectedAid }));
+    }
+};

--- a/src/workflows/credentials.op.ts
+++ b/src/workflows/credentials.op.ts
@@ -67,6 +67,7 @@ export function* resolveCredentialSchemaOp(
             status: 'resolving',
             title: null,
             description: null,
+            credentialType: null,
             version: null,
             rules: null,
             error: null,
@@ -91,6 +92,7 @@ export function* resolveCredentialSchemaOp(
                 status: 'error',
                 title: null,
                 description: null,
+                credentialType: null,
                 version: null,
                 rules: null,
                 error: toErrorText(error),
@@ -223,12 +225,23 @@ export function* syncCredentialInventoryOp(): EffectionOperation<
     CredentialSummaryRecord[]
 > {
     const services = yield* AppServicesContext.expect();
-    const credentials = yield* listCredentialInventoryService({
+    const inventory = yield* listCredentialInventoryService({
         client: services.runtime.requireConnectedClient(),
         localAids: localIdentifierAids(services.store),
     });
 
-    services.store.dispatch(credentialInventoryLoaded({ credentials }));
+    for (const schema of inventory.schemas) {
+        services.store.dispatch(schemaRecorded(schema));
+    }
+
+    const credentials = inventory.credentials;
+    services.store.dispatch(
+        credentialInventoryLoaded({
+            credentials,
+            acdcs: inventory.acdcs,
+            chainGraphs: inventory.chainGraphs,
+        })
+    );
     return credentials;
 }
 

--- a/tests/unit/credentialDomain.test.ts
+++ b/tests/unit/credentialDomain.test.ts
@@ -6,6 +6,8 @@ import type {
     Schema,
 } from 'signify-ts';
 import {
+    credentialAcdcRecordFromKeriaCredential,
+    credentialChainGraphFromKeriaCredential,
     credentialAdmitFromExchange,
     credentialGrantFromExchange,
     credentialRecordFromKeriaCredential,
@@ -94,6 +96,7 @@ describe('credential domain mappings', () => {
                 schema: {
                     title: 'SEDI Voter ID',
                     description: 'Demo credential',
+                    credentialType: 'SEDIVoterCredential',
                     version: '1.0.0',
                     rules: { issuer: 'SEDI' },
                 } as unknown as Schema,
@@ -107,6 +110,7 @@ describe('credential domain mappings', () => {
             status: 'resolved',
             title: 'SEDI Voter ID',
             description: 'Demo credential',
+            credentialType: 'SEDIVoterCredential',
             version: '1.0.0',
             rules: { issuer: 'SEDI' },
             error: null,
@@ -129,6 +133,68 @@ describe('credential domain mappings', () => {
             issuerAlias: 'issuer',
             issuerAid: 'Eissuer',
             status: 'ready',
+        });
+    });
+
+    it('extracts schema-level ACDC rules from the credential r property', () => {
+        expect(
+            schemaRecordFromKeriaSchema({
+                schema: {
+                    title: 'Verifiable Reference Data (VRD) Credential',
+                    credentialType: 'VRDCredential',
+                    properties: {
+                        r: {
+                            oneOf: [
+                                {
+                                    description: 'Rules block SAID',
+                                    type: 'string',
+                                },
+                                {
+                                    description: 'Rules block',
+                                    type: 'object',
+                                    properties: {
+                                        d: {
+                                            description: 'Rules block SAID',
+                                            type: 'string',
+                                        },
+                                        usageDisclaimer: {
+                                            description: 'Usage Disclaimer',
+                                            type: 'object',
+                                            properties: {
+                                                l: {
+                                                    description:
+                                                        'Associated legal language',
+                                                    type: 'string',
+                                                    const: '',
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                } as unknown as Schema,
+                said: 'EresolvedSchema',
+                oobi: null,
+                updatedAt: loadedAt,
+            }).rules
+        ).toEqual({
+            d: {
+                description: 'Rules block SAID',
+                type: 'string',
+            },
+            usageDisclaimer: {
+                description: 'Usage Disclaimer',
+                type: 'object',
+                properties: {
+                    l: {
+                        description: 'Associated legal language',
+                        type: 'string',
+                        const: '',
+                    },
+                },
+            },
         });
     });
 
@@ -172,6 +238,185 @@ describe('credential domain mappings', () => {
                 true
             )
         ).toBe('revoked');
+    });
+
+    it('projects generic ACDC data, rules, and chained source graph records', () => {
+        const root = {
+            sad: {
+                d: 'Eroot',
+                s: 'ErootSchema',
+                i: 'Eissuer',
+                ri: 'Eregistry',
+                a: {
+                    d: 'ErootSubject',
+                    i: 'Eholder',
+                    LEI: '5493001KJTIIGC8Y1R12',
+                    dt: loadedAt,
+                },
+                r: {
+                    usage: {
+                        value: 'demo',
+                    },
+                },
+                e: {
+                    legalEntity: {
+                        n: 'Ele',
+                        o: 'I2I',
+                    },
+                    missingSource: {
+                        n: 'Emissing',
+                    },
+                },
+            },
+            chains: [
+                {
+                    sad: {
+                        d: 'Ele',
+                        s: 'Eleschema',
+                        i: 'Eqvi',
+                        ri: 'EleRegistry',
+                        a: {
+                            d: 'EleSubject',
+                            i: 'Eholder',
+                            dt: loadedAt,
+                        },
+                        e: {
+                            gleif: {
+                                n: 'Egleif',
+                            },
+                        },
+                    },
+                    chains: [
+                        {
+                            sad: {
+                                d: 'Egleif',
+                                s: 'EgleifSchema',
+                                i: 'Egleif',
+                                a: {
+                                    d: 'EgleifSubject',
+                                    i: 'Egleif',
+                                    dt: loadedAt,
+                                },
+                            },
+                            chains: [],
+                            status: { et: 'iss' },
+                        },
+                    ],
+                    status: { et: 'iss' },
+                },
+            ],
+            status: { et: 'iss' },
+        } as unknown as CredentialResult;
+
+        expect(
+            credentialAcdcRecordFromKeriaCredential({
+                credential: root,
+                status: 'issued',
+                updatedAt: loadedAt,
+            })
+        ).toMatchObject({
+            said: 'Eroot',
+            schemaSaid: 'ErootSchema',
+            issuerAid: 'Eissuer',
+            holderAid: 'Eholder',
+            rules: { usage: { value: 'demo' } },
+            edges: [
+                {
+                    label: 'legalEntity',
+                    said: 'Ele',
+                    operator: 'I2I',
+                },
+                {
+                    label: 'missingSource',
+                    said: 'Emissing',
+                    operator: null,
+                },
+            ],
+        });
+
+        const graph = credentialChainGraphFromKeriaCredential({
+            credential: root,
+            updatedAt: loadedAt,
+        });
+
+        expect(graph.rootSaid).toBe('Eroot');
+        expect(graph.nodes).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ said: 'Eroot', unresolved: false }),
+                expect.objectContaining({ said: 'Ele', unresolved: false }),
+                expect.objectContaining({ said: 'Egleif', unresolved: false }),
+                expect.objectContaining({ said: 'Emissing', unresolved: true }),
+            ])
+        );
+        expect(graph.edges).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    from: 'Ele',
+                    to: 'Eroot',
+                    label: 'legalEntity',
+                }),
+                expect.objectContaining({
+                    from: 'Egleif',
+                    to: 'Ele',
+                    label: 'gleif',
+                }),
+                expect.objectContaining({
+                    from: 'Emissing',
+                    to: 'Eroot',
+                    label: 'missingSource',
+                }),
+            ])
+        );
+        expect(graph.nodes.find((node) => node.said === 'Eroot')?.depth).toBe(0);
+        expect(graph.nodes.find((node) => node.said === 'Egleif')?.depth).toBe(2);
+    });
+
+    it('de-dupes shared chained credentials and ignores graph cycles', () => {
+        const shared = {
+            sad: {
+                d: 'Eshared',
+                s: 'EsharedSchema',
+                i: 'Eissuer',
+                a: { i: 'Eholder' },
+                e: {
+                    backToRoot: {
+                        n: 'Eroot',
+                    },
+                },
+            },
+            chains: [],
+        };
+        const root = {
+            sad: {
+                d: 'Eroot',
+                s: 'ErootSchema',
+                i: 'Eissuer',
+                a: { i: 'Eholder' },
+                e: {
+                    first: {
+                        n: 'Eshared',
+                    },
+                    second: {
+                        n: 'Eshared',
+                    },
+                },
+            },
+            chains: [shared, shared],
+        } as unknown as CredentialResult;
+
+        const graph = credentialChainGraphFromKeriaCredential({
+            credential: root,
+            updatedAt: loadedAt,
+        });
+
+        expect(graph.nodes.filter((node) => node.said === 'Eshared')).toHaveLength(1);
+        expect(graph.nodes.find((node) => node.said === 'Eroot')?.depth).toBe(0);
+        expect(graph.edges).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ from: 'Eshared', to: 'Eroot' }),
+                expect.objectContaining({ from: 'Eroot', to: 'Eshared' }),
+            ])
+        );
     });
 
     it('projects credential subjects through the schema-aware boundary', () => {

--- a/tests/unit/credentialIssuanceUx.test.ts
+++ b/tests/unit/credentialIssuanceUx.test.ts
@@ -14,6 +14,7 @@ import {
     registryTilesForIssuer,
     walletStatsForAid,
 } from '../../src/features/credentials/credentialViewModels';
+import { schemaLabel } from '../../src/features/credentials/credentialDisplay';
 import { credentialRecorded } from '../../src/state/credentials.slice';
 import { registryInventoryLoaded } from '../../src/state/registry.slice';
 import { schemaRecorded } from '../../src/state/schema.slice';
@@ -143,6 +144,7 @@ describe('credential issuance UX selectors', () => {
                 status: 'resolved',
                 title: 'SEDI Voter ID Credential',
                 description: 'Schema',
+                credentialType: 'SEDIVoterCredential',
                 version: '1.0.0',
                 error: null,
                 updatedAt: now,
@@ -178,6 +180,66 @@ describe('credential issuance UX selectors', () => {
                 lastIssuedAt: now,
             }
         );
+    });
+
+    it('prefers resolved schema names over catalog labels and schema SAIDs', () => {
+        const types = selectIssueableCredentialTypeViews(createAppStore().getState());
+        const credentialTypesBySchema = new Map(
+            types.map((type) => [type.schemaSaid, type])
+        );
+        const schemaSaid = types[0]?.schemaSaid ?? 'Eschema';
+
+        expect(
+            schemaLabel(
+                schemaSaid,
+                credentialTypesBySchema,
+                new Map([
+                    [
+                        schemaSaid,
+                        {
+                            said: schemaSaid,
+                            oobi: null,
+                            status: 'resolved',
+                            title: 'Resolved Credential Title',
+                            description: null,
+                            credentialType: 'ResolvedCredentialType',
+                            version: null,
+                            error: null,
+                            updatedAt: now,
+                        },
+                    ],
+                ])
+            )
+        ).toBe('Resolved Credential Title');
+        expect(
+            schemaLabel(
+                'Evrdschemaaaaaaaaaaaaaaaaaaaaa',
+                new Map(),
+                new Map([
+                    [
+                        'Evrdschemaaaaaaaaaaaaaaaaaaaaa',
+                        {
+                            said: 'Evrdschemaaaaaaaaaaaaaaaaaaaaa',
+                            oobi: null,
+                            status: 'resolved',
+                            title: null,
+                            description: null,
+                            credentialType: 'VRDCredential',
+                            version: null,
+                            error: null,
+                            updatedAt: now,
+                        },
+                    ],
+                ])
+            )
+        ).toBe('VRDCredential');
+        expect(
+            schemaLabel(
+                'EunknownSchemaSaidValue',
+                new Map(),
+                new Map()
+            )
+        ).not.toBe('Credential schema');
     });
 
     it('stores multiple registry inventory records keyed by registry id', () => {
@@ -273,6 +335,7 @@ describe('credential issuance UX selectors', () => {
                 status: 'resolved',
                 title: 'SEDI Voter ID Credential',
                 description: 'Schema',
+                credentialType: 'SEDIVoterCredential',
                 version: '1.0.0',
                 error: null,
                 updatedAt: now,

--- a/tests/unit/credentialWalletPanels.test.tsx
+++ b/tests/unit/credentialWalletPanels.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { HeldCredentialsPanel } from '../../src/features/credentials/CredentialWalletPanels';
+import type {
+    CredentialSummaryRecord,
+    SchemaRecord,
+} from '../../src/domain/credentials/credentialTypes';
+
+const credential = {
+    said: 'Ecredential',
+    schemaSaid: 'Eschema',
+    registryId: 'Eregistry',
+    issuerAid: 'Eissuer',
+    holderAid: 'Eholder',
+    direction: 'held',
+    status: 'admitted',
+    grantSaid: null,
+    admitSaid: null,
+    notificationId: null,
+    issuedAt: '2026-04-22T00:00:00.000Z',
+    grantedAt: null,
+    admittedAt: null,
+    revokedAt: null,
+    error: null,
+    attributes: null,
+    updatedAt: '2026-04-22T00:00:00.000Z',
+} satisfies CredentialSummaryRecord;
+
+const schema = {
+    said: 'Eschema',
+    oobi: null,
+    status: 'resolved',
+    title: 'Verifiable Reference Data (VRD) Credential',
+    description: null,
+    credentialType: 'VRDCredential',
+    version: null,
+    error: null,
+    updatedAt: null,
+} satisfies SchemaRecord;
+
+describe('wallet credential panels', () => {
+    it('renders held credential rows as detail navigation targets without inline expansion details', () => {
+        const markup = renderToStaticMarkup(
+            <HeldCredentialsPanel
+                credentials={[credential]}
+                credentialTypesBySchema={new Map()}
+                schemasBySaid={new Map([['Eschema', schema]])}
+                onOpenCredential={vi.fn()}
+            />
+        );
+
+        expect(markup).toContain('role="button"');
+        expect(markup).toContain('Verifiable Reference Data (VRD) Credential');
+        expect(markup).toContain('Ecredential');
+        expect(markup).not.toContain('Schema SAID');
+        expect(markup).not.toContain('Issuer');
+        expect(markup).not.toContain('Holder');
+    });
+});

--- a/tests/unit/credentialsService.test.ts
+++ b/tests/unit/credentialsService.test.ts
@@ -93,6 +93,13 @@ const admittedCredential = {
             expires: '2026-12-31T23:59:59Z',
         },
     },
+    schema: {
+        $id: 'Eschema',
+        title: 'Verifiable Reference Data (VRD) Credential',
+        description: 'A VRD credential',
+        credentialType: 'VRDCredential',
+        version: '1.0.0',
+    },
     status: { s: '0' },
 } as unknown as CredentialResult;
 
@@ -358,7 +365,41 @@ describe('credential service helpers', () => {
                                         eligible: true,
                                         expires: '2026-12-31T23:59:59Z',
                                     },
+                                    e: {
+                                        source: {
+                                            n: 'EsourceCredential',
+                                        },
+                                    },
                                 },
+                                schema: {
+                                    $id: 'Eschema',
+                                    title: 'Verifiable Reference Data (VRD) Credential',
+                                    description: 'A VRD credential',
+                                    credentialType: 'VRDCredential',
+                                    version: '1.0.0',
+                                },
+                                chains: [
+                                    {
+                                        sad: {
+                                            d: 'EsourceCredential',
+                                            s: 'EsourceSchema',
+                                            i: 'EsourceIssuer',
+                                            a: {
+                                                i: 'EsourceSubject',
+                                                LEI: '5493001KJTIIGC8Y1R12',
+                                            },
+                                        },
+                                        schema: {
+                                            $id: 'EsourceSchema',
+                                            title: 'Legal Entity vLEI Credential',
+                                            description: 'LE credential',
+                                            credentialType:
+                                                'LegalEntityvLEICredential',
+                                            version: '1.0.0',
+                                        },
+                                        status: { et: 'iss' },
+                                    },
+                                ],
                             },
                         ];
                     }
@@ -396,7 +437,7 @@ describe('credential service helpers', () => {
             expect(credentials.list).toHaveBeenCalledWith({
                 filter: { '-a-i': 'Eholder' },
             });
-            expect(inventory).toEqual([
+            expect(inventory.credentials).toEqual([
                 expect.objectContaining({
                     said: 'EissuedCredential',
                     issuerAid: 'Eissuer',
@@ -412,6 +453,48 @@ describe('credential service helpers', () => {
                     status: 'admitted',
                 }),
             ]);
+            expect(inventory.schemas).toEqual([
+                expect.objectContaining({
+                    said: 'Eschema',
+                    title: 'Verifiable Reference Data (VRD) Credential',
+                    credentialType: 'VRDCredential',
+                }),
+                expect.objectContaining({
+                    said: 'EsourceSchema',
+                    title: 'Legal Entity vLEI Credential',
+                    credentialType: 'LegalEntityvLEICredential',
+                }),
+            ]);
+            expect(inventory.acdcs).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        said: 'EissuedCredential',
+                        edges: [
+                            expect.objectContaining({
+                                label: 'source',
+                                said: 'EsourceCredential',
+                            }),
+                        ],
+                    }),
+                    expect.objectContaining({
+                        said: 'EsourceCredential',
+                        issuerAid: 'EsourceIssuer',
+                    }),
+                ])
+            );
+            expect(inventory.chainGraphs).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        rootSaid: 'EissuedCredential',
+                        nodes: expect.arrayContaining([
+                            expect.objectContaining({
+                                said: 'EsourceCredential',
+                                unresolved: false,
+                            }),
+                        ]),
+                    }),
+                ])
+            );
         } finally {
             await runtime.destroy();
         }
@@ -546,6 +629,7 @@ describe('credential service helpers', () => {
             get: vi.fn(async (said: string) => ({
                 title: `Schema ${said}`,
                 description: 'Known schema',
+                credentialType: 'KnownCredential',
                 version: '1.0.0',
                 rules: {
                     usageDisclaimer: {
@@ -577,6 +661,7 @@ describe('credential service helpers', () => {
                 said: credentialType.schemaSaid,
                 status: 'resolved',
                 title: `Schema ${credentialType.schemaSaid}`,
+                credentialType: 'KnownCredential',
                 rules: {
                     usageDisclaimer: {
                         l: 'Usage disclaimer',

--- a/tests/unit/dashboardCredentialDetail.test.tsx
+++ b/tests/unit/dashboardCredentialDetail.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { CredentialSummaryRecord } from '../../src/domain/credentials/credentialTypes';
+import {
+    canonicalCredentialWorkflowPath,
+    legacyDashboardCredentialRedirectPath,
+} from '../../src/features/dashboard/dashboardViewModels';
+
+const heldCredential = {
+    said: 'Eshared',
+    schemaSaid: 'Eschema',
+    registryId: 'Eregistry',
+    issuerAid: 'Eissuer',
+    holderAid: 'Eholder',
+    direction: 'held',
+    status: 'admitted',
+    grantSaid: null,
+    admitSaid: null,
+    notificationId: null,
+    issuedAt: null,
+    grantedAt: null,
+    admittedAt: null,
+    revokedAt: null,
+    error: null,
+    attributes: null,
+    updatedAt: '2026-04-22T00:00:00.000Z',
+} satisfies CredentialSummaryRecord;
+
+const issuedCredential = {
+    ...heldCredential,
+    direction: 'issued',
+    status: 'issued',
+} satisfies CredentialSummaryRecord;
+
+describe('dashboard credential workflow routing', () => {
+    it('routes held credentials to the holder wallet workflow', () => {
+        expect(canonicalCredentialWorkflowPath(heldCredential)).toBe(
+            '/credentials/Eholder/wallet'
+        );
+    });
+
+    it('routes issued credentials to the issuer workflow', () => {
+        expect(canonicalCredentialWorkflowPath(issuedCredential)).toBe(
+            '/credentials/Eissuer/issuer'
+        );
+    });
+
+    it('prefers held inventory for legacy dashboard SAID redirects', () => {
+        expect(
+            legacyDashboardCredentialRedirectPath({
+                credentialSaid: 'Eshared',
+                heldCredentials: [heldCredential],
+                issuedCredentials: [issuedCredential],
+            })
+        ).toBe('/credentials/Eholder/wallet');
+    });
+
+    it('falls back to the held dashboard list for unknown legacy SAIDs', () => {
+        expect(
+            legacyDashboardCredentialRedirectPath({
+                credentialSaid: 'Emissing',
+                heldCredentials: [],
+                issuedCredentials: [],
+            })
+        ).toBe('/dashboard/credentials/held');
+    });
+});

--- a/tests/unit/dashboardCredentialRules.test.ts
+++ b/tests/unit/dashboardCredentialRules.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import {
+    credentialGraphNodeLabel,
+    credentialRulesRows,
+    credentialSubjectDataRows,
+} from '../../src/features/dashboard/credentialAcdcDisplay';
 import { schemaRuleViews } from '../../src/features/dashboard/schemaRules';
 
 describe('dashboard credential schema rules', () => {
@@ -55,5 +60,108 @@ describe('dashboard credential schema rules', () => {
             { name: 'emptyObject', value: '{}' },
             { name: 'emptyArray', value: '[]' },
         ]);
+    });
+
+    it('flattens arbitrary ACDC subject data and credential rules', () => {
+        const acdc = {
+            said: 'Ecredential',
+            schemaSaid: 'Eschema',
+            registryId: 'Eregistry',
+            issuerAid: 'Eissuer',
+            holderAid: 'Eholder',
+            subject: {
+                d: 'Esubject',
+                i: 'Eholder',
+                LEI: '5493001KJTIIGC8Y1R12',
+                flags: ['active', 'verified'],
+            },
+            rules: [{ usage: 'demo' }],
+            edges: [],
+            status: 'admitted',
+            updatedAt: '2026-04-22T00:00:00.000Z',
+        } as const;
+
+        expect(
+            credentialSubjectDataRows(acdc, {
+                said: 'Eschema',
+                oobi: null,
+                status: 'resolved',
+                title: 'Legal Entity vLEI Credential',
+                description: null,
+                credentialType: 'LegalEntityvLEICredential',
+                version: null,
+                properties: {
+                    a: {
+                        properties: {
+                            LEI: {
+                                title: 'Legal Entity Identifier',
+                                description: 'GLEIF LEI',
+                            },
+                        },
+                    },
+                },
+                error: null,
+                updatedAt: null,
+            })
+        ).toEqual([
+            {
+                name: 'd',
+                label: 'Subject SAID',
+                value: 'Esubject',
+                description: null,
+            },
+            {
+                name: 'i',
+                label: 'Subject AID',
+                value: 'Eholder',
+                description: null,
+            },
+            {
+                name: 'LEI',
+                label: 'Legal Entity Identifier',
+                value: '5493001KJTIIGC8Y1R12',
+                description: 'GLEIF LEI',
+            },
+            {
+                name: 'flags',
+                label: 'flags',
+                value: JSON.stringify(['active', 'verified'], null, 2),
+                description: null,
+            },
+        ]);
+        expect(credentialRulesRows(acdc)).toEqual([
+            { name: 'rules.0.usage', value: 'demo' },
+        ]);
+    });
+
+    it('uses resolved human-readable type names for graph nodes', () => {
+        expect(
+            credentialGraphNodeLabel({
+                node: {
+                    said: 'Ecredential',
+                    schemaSaid: 'Eschema',
+                    issuerAid: 'Eissuer',
+                    holderAid: 'Eholder',
+                    unresolved: false,
+                    depth: 0,
+                },
+                schemasBySaid: new Map([
+                    [
+                        'Eschema',
+                        {
+                            said: 'Eschema',
+                            oobi: null,
+                            status: 'resolved',
+                            title: 'Verifiable Reference Data (VRD) Credential',
+                            description: null,
+                            credentialType: 'VRDCredential',
+                            version: null,
+                            error: null,
+                            updatedAt: null,
+                        },
+                    ],
+                ]),
+            })
+        ).toBe('Verifiable Reference Data (VRD) Credential');
     });
 });

--- a/tests/unit/identifierComponents.test.tsx
+++ b/tests/unit/identifierComponents.test.tsx
@@ -13,6 +13,7 @@ describe('identifier UI actions', () => {
         const markup = renderToStaticMarkup(
             <IdentifierTable
                 identifiers={[identifier]}
+                selectedAid={null}
                 onSelect={vi.fn()}
                 onRotate={vi.fn()}
                 isRotateDisabled={() => false}
@@ -22,6 +23,22 @@ describe('identifier UI actions', () => {
         );
 
         expect(markup).toContain('aria-label="Copy agent OOBI for alice"');
-        expect(markup).not.toContain('aria-label="Authorize agent for alice"');
+        expect(markup).not.toContain('Authorize agent');
+    });
+
+    it('marks the globally selected identifier row', () => {
+        const markup = renderToStaticMarkup(
+            <IdentifierTable
+                identifiers={[identifier]}
+                selectedAid="Ealice"
+                onSelect={vi.fn()}
+                onRotate={vi.fn()}
+                isRotateDisabled={() => false}
+                onCopyAgentOobi={vi.fn()}
+                agentOobiCopyStatus={{}}
+            />
+        );
+
+        expect(markup).toContain('aria-selected="true"');
     });
 });

--- a/tests/unit/runtimeWorkflow.test.ts
+++ b/tests/unit/runtimeWorkflow.test.ts
@@ -19,6 +19,8 @@ import {
 } from '../../src/state/persistence';
 import { selectActiveOperations } from '../../src/state/selectors';
 import { createAppStore } from '../../src/state/store';
+import { walletAidSelected } from '../../src/state/walletSelection.slice';
+import { MemoryWalletSelectionPersistenceStore } from '../../src/state/walletSelectionPersistence';
 
 /**
  * Minimal storage fake used to exercise controller-scoped persistence.
@@ -220,7 +222,15 @@ describe('AppRuntime workflow bridge', () => {
     it('clears persisted local buckets and current persisted projections', async () => {
         const store = createAppStore();
         const storage = new MemoryStorage();
-        const runtime = createAppRuntime({ store, storage });
+        const walletSelectionStorage =
+            new MemoryWalletSelectionPersistenceStore();
+        await walletSelectionStorage.save('Econtroller1', 'Ealice');
+        store.dispatch(walletAidSelected({ aid: 'Ealice' }));
+        const runtime = createAppRuntime({
+            store,
+            storage,
+            walletSelectionStorage,
+        });
 
         storage.setItem(
             persistedAppStateKey('Econtroller1'),
@@ -280,6 +290,9 @@ describe('AppRuntime workflow bridge', () => {
         );
 
         expect(runtime.clearAllLocalState()).toBe(2);
+        await vi.waitFor(async () => {
+            expect(await walletSelectionStorage.load('Econtroller1')).toBeNull();
+        });
 
         expect(
             storage.getItem(persistedAppStateKey('Econtroller1'))
@@ -291,6 +304,63 @@ describe('AppRuntime workflow bridge', () => {
         expect(store.getState().appNotifications.ids).toEqual([]);
         expect(store.getState().exchangeTombstones.saids).toEqual([]);
         expect(store.getState().challenges.storedWordIds).toEqual([]);
+        expect(store.getState().walletSelection.selectedAid).toBeNull();
+
+        await runtime.destroy();
+    });
+
+    it('rehydrates selected wallet AID after the controller bucket is known', async () => {
+        const store = createAppStore();
+        const walletSelectionStorage =
+            new MemoryWalletSelectionPersistenceStore();
+        await walletSelectionStorage.save('Econtroller', 'Ealice');
+        const runtime = createAppRuntime({
+            store,
+            storage: null,
+            walletSelectionStorage,
+        });
+
+        (
+            runtime as unknown as {
+                setPersistenceController(controllerAid: string | null): void;
+            }
+        ).setPersistenceController('Econtroller');
+
+        await vi.waitFor(() => {
+            expect(store.getState().walletSelection.selectedAid).toBe('Ealice');
+        });
+
+        await runtime.destroy();
+    });
+
+    it('does not let selected-wallet rehydration overwrite a newer selection', async () => {
+        const store = createAppStore();
+        const walletSelectionStorage =
+            new MemoryWalletSelectionPersistenceStore();
+        await walletSelectionStorage.save('Econtroller', 'Eold');
+        const runtime = createAppRuntime({
+            store,
+            storage: null,
+            walletSelectionStorage,
+        });
+
+        (
+            runtime as unknown as {
+                setPersistenceController(controllerAid: string | null): void;
+            }
+        ).setPersistenceController('Econtroller');
+        store.dispatch(walletAidSelected({ aid: 'Enew' }));
+
+        await vi.waitFor(() => {
+            expect(store.getState().walletSelection.selectedAid).toBe('Enew');
+        });
+        await vi.waitFor(async () => {
+            expect(await walletSelectionStorage.load('Econtroller')).toMatchObject(
+                {
+                    selectedAid: 'Enew',
+                }
+            );
+        });
 
         await runtime.destroy();
     });

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -20,6 +20,8 @@ import {
     selectChallenges,
     selectChallengesForContact,
     selectDashboardCounts,
+    selectCredentialAcdc,
+    selectCredentialChainGraph,
     selectCredentialIpexActivity,
     selectActionableChallengeRequestNotifications,
     selectActionableCredentialGrantNotifications,
@@ -54,6 +56,7 @@ import {
     appNotificationRecorded,
 } from '../../src/state/appNotifications.slice';
 import {
+    credentialInventoryLoaded,
     credentialIpexActivityLoaded,
     credentialRecorded,
 } from '../../src/state/credentials.slice';
@@ -388,6 +391,7 @@ describe('RTK state foundation', () => {
                 status: 'resolved',
                 title: 'Resolved schema',
                 description: null,
+                credentialType: 'ResolvedCredential',
                 version: null,
                 error: null,
                 updatedAt: '2026-04-21T00:00:00.000Z',
@@ -400,6 +404,7 @@ describe('RTK state foundation', () => {
                 status: 'error',
                 title: null,
                 description: null,
+                credentialType: null,
                 version: null,
                 error: 'not found',
                 updatedAt: '2026-04-21T00:00:01.000Z',
@@ -504,6 +509,108 @@ describe('RTK state foundation', () => {
             expect.objectContaining({ exchangeSaid: 'Egrant' }),
             expect.objectContaining({ exchangeSaid: 'Eadmit' }),
         ]);
+    });
+
+    it('stores generic ACDC details and chain graphs from inventory sync', () => {
+        const store = createAppStore();
+
+        store.dispatch(
+            credentialInventoryLoaded({
+                credentials: [
+                    {
+                        said: 'credential-root',
+                        schemaSaid: 'schema-root',
+                        registryId: 'registry-1',
+                        issuerAid: 'Eissuer',
+                        holderAid: 'Eholder',
+                        direction: 'held',
+                        status: 'admitted',
+                        grantSaid: null,
+                        admitSaid: null,
+                        notificationId: null,
+                        issuedAt: null,
+                        grantedAt: null,
+                        admittedAt: null,
+                        revokedAt: null,
+                        error: null,
+                        attributes: null,
+                        updatedAt: '2026-04-21T00:00:00.000Z',
+                    },
+                ],
+                acdcs: [
+                    {
+                        said: 'credential-root',
+                        schemaSaid: 'schema-root',
+                        registryId: 'registry-1',
+                        issuerAid: 'Eissuer',
+                        holderAid: 'Eholder',
+                        subject: { i: 'Eholder', LEI: '5493001KJTIIGC8Y1R12' },
+                        rules: { usage: 'demo' },
+                        edges: [
+                            {
+                                label: 'source',
+                                said: 'credential-source',
+                                operator: null,
+                                data: { n: 'credential-source' },
+                            },
+                        ],
+                        status: 'admitted',
+                        updatedAt: '2026-04-21T00:00:00.000Z',
+                    },
+                ],
+                chainGraphs: [
+                    {
+                        rootSaid: 'credential-root',
+                        nodes: [
+                            {
+                                said: 'credential-source',
+                                schemaSaid: 'schema-source',
+                                issuerAid: 'Eissuer',
+                                holderAid: 'Eholder',
+                                unresolved: false,
+                                depth: 1,
+                            },
+                            {
+                                said: 'credential-root',
+                                schemaSaid: 'schema-root',
+                                issuerAid: 'Eissuer',
+                                holderAid: 'Eholder',
+                                unresolved: false,
+                                depth: 0,
+                            },
+                        ],
+                        edges: [
+                            {
+                                id: 'credential-source->credential-root:source',
+                                from: 'credential-source',
+                                to: 'credential-root',
+                                label: 'source',
+                                operator: null,
+                            },
+                        ],
+                        updatedAt: '2026-04-21T00:00:00.000Z',
+                    },
+                ],
+            })
+        );
+
+        expect(
+            selectCredentialAcdc('credential-root')(store.getState())
+        ).toMatchObject({
+            said: 'credential-root',
+            subject: { i: 'Eholder', LEI: '5493001KJTIIGC8Y1R12' },
+        });
+        expect(
+            selectCredentialChainGraph('credential-root')(store.getState())
+        ).toMatchObject({
+            rootSaid: 'credential-root',
+            edges: [
+                expect.objectContaining({
+                    from: 'credential-source',
+                    to: 'credential-root',
+                }),
+            ],
+        });
     });
 
     it('preserves workflow challenge records across inventory refreshes', () => {
@@ -714,6 +821,10 @@ describe('RTK state foundation', () => {
                 said: 'schema-1',
                 oobi: 'http://127.0.0.1:3902/oobi/schema-1',
                 status: 'resolved',
+                title: 'Schema one',
+                description: null,
+                credentialType: 'SchemaOneCredential',
+                version: null,
                 error: null,
                 updatedAt: '2026-04-21T00:00:04.000Z',
             })

--- a/tests/unit/walletSelectionPersistence.test.ts
+++ b/tests/unit/walletSelectionPersistence.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAppStore } from '../../src/state/store';
+import { walletAidSelected } from '../../src/state/walletSelection.slice';
+import {
+    installWalletSelectionPersistence,
+    MemoryWalletSelectionPersistenceStore,
+    rehydrateWalletSelection,
+} from '../../src/state/walletSelectionPersistence';
+
+describe('wallet selection persistence', () => {
+    it('saves, loads, clears, and scopes selected AIDs by controller AID', async () => {
+        const storage = new MemoryWalletSelectionPersistenceStore();
+
+        await storage.save('Econtroller1', ' Ealice ');
+        await storage.save('Econtroller2', 'Ebob');
+
+        expect(await storage.load('Econtroller1')).toMatchObject({
+            controllerAid: 'Econtroller1',
+            selectedAid: 'Ealice',
+        });
+        expect(await storage.load('Econtroller2')).toMatchObject({
+            selectedAid: 'Ebob',
+        });
+
+        await storage.save('Econtroller1', null);
+        expect(await storage.load('Econtroller1')).toMatchObject({
+            selectedAid: null,
+        });
+        expect(await storage.clearAll()).toBe(2);
+        expect(await storage.load('Econtroller2')).toBeNull();
+    });
+
+    it('persists wallet selection changes through one shared store', async () => {
+        const store = createAppStore();
+        const storage = new MemoryWalletSelectionPersistenceStore();
+        let controllerAid: string | null = 'Econtroller1';
+        const uninstall = installWalletSelectionPersistence(
+            store,
+            () => controllerAid,
+            storage
+        );
+
+        store.dispatch(walletAidSelected({ aid: 'Ealice' }));
+        await vi.waitFor(async () => {
+            expect(await storage.load('Econtroller1')).toMatchObject({
+                selectedAid: 'Ealice',
+            });
+        });
+
+        controllerAid = 'Econtroller2';
+        store.dispatch(walletAidSelected({ aid: 'Ebob' }));
+        await vi.waitFor(async () => {
+            expect(await storage.load('Econtroller2')).toMatchObject({
+                selectedAid: 'Ebob',
+            });
+        });
+
+        uninstall();
+        expect(await storage.load('Econtroller1')).toMatchObject({
+            selectedAid: 'Ealice',
+        });
+    });
+
+    it('rehydrates persisted selection without overwriting a newer user selection', async () => {
+        const store = createAppStore();
+        const storage = new MemoryWalletSelectionPersistenceStore();
+        await storage.save('Econtroller', 'Eold');
+
+        const rehydrating = rehydrateWalletSelection({
+            store,
+            controllerAid: 'Econtroller',
+            storage,
+            canApply: () => true,
+        });
+        store.dispatch(walletAidSelected({ aid: 'Enew' }));
+        await rehydrating;
+
+        expect(store.getState().walletSelection.selectedAid).toBe('Enew');
+    });
+
+    it('skips stale async rehydration when the controller changes', async () => {
+        const store = createAppStore();
+        const storage = new MemoryWalletSelectionPersistenceStore();
+        await storage.save('Econtroller', 'Eold');
+
+        await rehydrateWalletSelection({
+            store,
+            controllerAid: 'Econtroller',
+            storage,
+            canApply: () => false,
+        });
+
+        expect(store.getState().walletSelection.selectedAid).toBeNull();
+    });
+});


### PR DESCRIPTION
Stack PR 3/8 for splitting #34.

Scope:
- Improves credential UX foundations and shared credential display behavior before the W3C feature branches.

Base branch: split/pr34-02-didwebs-projection
Head branch: split/pr34-03-credential-ux-foundation

Validation performed on final stack:
- pnpm lint
- pnpm build
- pnpm unit:test
- w3c-crosswalk make local-seed
- w3c-crosswalk make local-test
- pnpm w3c:holder-presentation:smoke