### PR TITLE
feat: add container image build tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.ci
+.tmp
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable \
+    && corepack prepare pnpm@10.33.0 --activate
+
+ARG SIGNIFY_TS_PACKAGE
+ENV PUPPETEER_SKIP_DOWNLOAD=1
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Portable stack builds can pin signify-ts to an immutable Git/package input
+# without editing the checked-in package.json. Keep the mutation in a source
+# file so the build policy is reviewable and testable outside Docker.
+COPY scripts/set-signify-ts-package.mjs scripts/set-signify-ts-package.mjs
+RUN node scripts/set-signify-ts-package.mjs
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+ENV HOST=0.0.0.0
+ENV PORT=5177
+
+EXPOSE 5177
+
+CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "5177"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+CONTAINER_ENGINE ?= docker
+DOCKER_IMAGE_REPOSITORY ?= kentbull/signify-react-ts
+DOCKER_IMAGE_TAG ?= $(shell git rev-parse HEAD)
+DOCKER_LATEST_TAG ?= latest
+DOCKERFILE ?= Dockerfile
+DOCKER_BUILD_CONTEXT ?= .
+SIGNIFY_TS_PACKAGE ?=
+
+.PHONY: help docker-build docker-push docker-publish
+
+help: ## Show available maintainer tasks
+	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z0-9_-]+:.*## / {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+docker-build: ## Build Docker Hub SHA and latest tags for the wallet image
+	@CONTAINER_ENGINE="$(CONTAINER_ENGINE)" \
+		DOCKER_IMAGE_REPOSITORY="$(DOCKER_IMAGE_REPOSITORY)" \
+		DOCKER_IMAGE_TAG="$(DOCKER_IMAGE_TAG)" \
+		DOCKER_LATEST_TAG="$(DOCKER_LATEST_TAG)" \
+		DOCKERFILE="$(DOCKERFILE)" \
+		DOCKER_BUILD_CONTEXT="$(DOCKER_BUILD_CONTEXT)" \
+		SIGNIFY_TS_PACKAGE="$(SIGNIFY_TS_PACKAGE)" \
+		bash scripts/container-image.sh build
+
+docker-push: ## Push Docker Hub SHA and latest tags for the wallet image
+	@CONTAINER_ENGINE="$(CONTAINER_ENGINE)" \
+		DOCKER_IMAGE_REPOSITORY="$(DOCKER_IMAGE_REPOSITORY)" \
+		DOCKER_IMAGE_TAG="$(DOCKER_IMAGE_TAG)" \
+		DOCKER_LATEST_TAG="$(DOCKER_LATEST_TAG)" \
+		bash scripts/container-image.sh push
+
+docker-publish: docker-build docker-push ## Build and push Docker Hub wallet image tags

--- a/docs/container-build.md
+++ b/docs/container-build.md
@@ -1,0 +1,54 @@
+# Container build
+
+The Docker image runs the wallet against a KERIA+Signify stack. It builds from
+this repository plus package/image inputs.
+
+Default stack builds should consume published packages, immutable Git SHAs, or
+OCI images. Do not make the portable stack depend on a sibling `signify-ts`
+source checkout. Local tree overrides are acceptable only as explicit developer
+experiments outside the default build contract.
+
+## Build and publish
+
+Use the repo-owned Make targets to build or publish the wallet image:
+
+```bash
+make docker-build
+make docker-publish
+```
+
+The defaults are:
+
+| Variable                  | Default                      |
+|---------------------------|------------------------------|
+| `CONTAINER_ENGINE`        | `docker`                     |
+| `DOCKER_IMAGE_REPOSITORY` | `kentbull/signify-react-ts`  |
+| `DOCKER_IMAGE_TAG`        | current `git rev-parse HEAD` |
+| `DOCKER_LATEST_TAG`       | `latest`                     |
+
+`docker-build` tags both `DOCKER_IMAGE_REPOSITORY:DOCKER_IMAGE_TAG` and
+`DOCKER_IMAGE_REPOSITORY:DOCKER_LATEST_TAG`. `docker-publish` builds and pushes
+both tags.
+
+## `SIGNIFY_TS_PACKAGE`
+
+`SIGNIFY_TS_PACKAGE` is an optional Docker build input that replaces the
+`signify-ts` dependency in `package.json` before `pnpm install` runs:
+
+```bash
+make docker-build \
+  SIGNIFY_TS_PACKAGE='git+https://github.com/kentbull/signify-ts.git#<sha>'
+```
+
+The override is passed through to the Docker build and handled by
+[`scripts/set-signify-ts-package.mjs`](../scripts/set-signify-ts-package.mjs).
+
+The helper only rewrites the copied `package.json` inside the Docker build
+context. It does not modify the working tree and does not regenerate
+`pnpm-lock.yaml`. Because the Dockerfile uses `pnpm install --frozen-lockfile`,
+the checked-in lockfile must already be compatible with the requested
+`SIGNIFY_TS_PACKAGE`.
+
+For cross-repo validation, prefer a pushed GitHub SHA from the intended
+`signify-ts` branch over a `file:` dependency. That keeps browser, Docker, and
+headless runs reproducible across machines.

--- a/scripts/container-image.sh
+++ b/scripts/container-image.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-build}"
+
+container_engine="${CONTAINER_ENGINE:-docker}"
+image_repository="${DOCKER_IMAGE_REPOSITORY:-kentbull/signify-react-ts}"
+image_tag="${DOCKER_IMAGE_TAG:-$(git rev-parse HEAD)}"
+latest_tag="${DOCKER_LATEST_TAG:-latest}"
+dockerfile="${DOCKERFILE:-Dockerfile}"
+build_context="${DOCKER_BUILD_CONTEXT:-.}"
+
+version_image="${image_repository}:${image_tag}"
+latest_image="${image_repository}:${latest_tag}"
+
+build_image() {
+  local args=(
+    build
+    -f "$dockerfile"
+    -t "$version_image"
+    -t "$latest_image"
+  )
+
+  if [[ -n "${SIGNIFY_TS_PACKAGE:-}" ]]; then
+    args+=(--build-arg "SIGNIFY_TS_PACKAGE=$SIGNIFY_TS_PACKAGE")
+  fi
+
+  args+=("$build_context")
+  "$container_engine" "${args[@]}"
+}
+
+push_image() {
+  "$container_engine" push "$version_image"
+  "$container_engine" push "$latest_image"
+}
+
+case "$command" in
+  build)
+    build_image
+    ;;
+  push)
+    push_image
+    ;;
+  publish)
+    build_image
+    push_image
+    ;;
+  *)
+    echo "usage: $0 {build|push|publish}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/set-signify-ts-package.mjs
+++ b/scripts/set-signify-ts-package.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Apply the Docker-only signify-ts dependency override. Intended to be run by
+ * an outer build orchestrator script.
+ *
+ * Container builds use a pinned signify-react-ts commit while optionally
+ * pinning signify-ts independently. The repository package.json keeps the
+ * default dependency for normal development; Docker builds may pass
+ * SIGNIFY_TS_PACKAGE to test or publish a wallet image against a different
+ * immutable signify-ts package, tarball, or Git SHA.
+ *
+ * This script runs before `pnpm install --frozen-lockfile` in the Dockerfile.
+ * That means the override must already be compatible with the copied lockfile;
+ * the script intentionally rewrites only package.json and does not regenerate
+ * package-manager state inside the image build.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const packageOverride = process.env.SIGNIFY_TS_PACKAGE;
+
+if (!packageOverride) {
+    process.exit(0);
+}
+
+const packagePath = 'package.json';
+const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+packageJson.dependencies ??= {};
+packageJson.dependencies['signify-ts'] = packageOverride;
+
+writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 4)}\n`);


### PR DESCRIPTION
Stack PR 5/8 for splitting #34.

Scope:
- Adds portable container image build tooling and dependency override support.

Base branch: split/pr34-04-light-theme
Head branch: split/pr34-05-container-build

Validation performed on final stack:
- pnpm lint
- pnpm build
- pnpm unit:test
- w3c-crosswalk make local-seed
- w3c-crosswalk make local-test
- pnpm w3c:holder-presentation:smoke